### PR TITLE
[Freshness Auto-Fix] Replaced dead link `https://ai.google.dev/pricing` → `https://cloud.google.com/p

### DIFF
--- a/public/days/day-01.js
+++ b/public/days/day-01.js
@@ -100,7 +100,7 @@ monthly cost = daily cost × 30</pre>
 # Links to all provider pricing pages:
 #   Anthropic : https://www.anthropic.com/pricing
 #   OpenAI    : https://openai.com/pricing
-#   Google    : https://ai.google.dev/pricing
+#   Google    : https://cloud.google.com/pricing
 #   Microsoft : https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
 #   Nvidia    : https://build.nvidia.com/  (NIM API pricing)
 #
@@ -214,7 +214,7 @@ print("     Optimise prompts (input) AND response length (output) for cost contr
     { type: 'DOCS',    title: 'Anthropic — Models Overview',         url: 'https://docs.anthropic.com/en/docs/about-claude/models',                                              note: 'Current Claude model strings, context limits, and capability notes. Bookmark this.' },
     { type: 'PRICING', title: 'Anthropic — API Pricing (live)',       url: 'https://www.anthropic.com/pricing',                                                                   note: 'Pull live pricing before every cost estimate. Never hardcode.' },
     { type: 'PRICING', title: 'OpenAI — API Pricing (live)',          url: 'https://openai.com/pricing',                                                                          note: 'GPT-4o vs o-series pricing tradeoffs. Verify before any estimate.' },
-    { type: 'PRICING', title: 'Google — Gemini API Pricing (live)',   url: 'https://ai.google.dev/pricing',                                                                       note: 'Gemini 2.5 Pro and Flash pricing. Includes free tier details.' },
+    { type: 'PRICING', title: 'Google — Gemini API Pricing (live)',   url: 'https://cloud.google.com/pricing',                                                                       note: 'Gemini 2.5 Pro and Flash pricing. Includes free tier details.' },
     { type: 'PRICING', title: 'Microsoft — Azure OpenAI Pricing',    url: 'https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/',              note: 'GPT + MAI models on Azure. Relevant for enterprise Azure-first customers.' },
     { type: 'PRICING', title: 'Nvidia — NIM API Pricing',             url: 'https://build.nvidia.com/',                                                                           note: 'Nemotron and partner models via Nvidia’s hosted inference API.' },
     { type: 'DOCS',    title: 'Meta — Llama 4 Model Card',            url: 'https://ai.meta.com/blog/llama-4-multimodal-intelligence/',                                          note: 'Llama 4 architecture and license. Understand open-weight strategy.' },


### PR DESCRIPTION
Closes #43

## Auto-fix summary
Replaced dead link `https://ai.google.dev/pricing` → `https://cloud.google.com/pricing`

## Edits applied

**From:**
```
https://ai.google.dev/pricing
```
**To:**
```
https://cloud.google.com/pricing
```

---
*Auto-generated by freshness-auto-fix.mjs. Please review before merging.*