### PR TITLE
fix: merge progress_data on save; tighten leaderboard filter

### DIFF
--- a/api/leaderboard.js
+++ b/api/leaderboard.js
@@ -22,7 +22,7 @@ export default async function handler(req, res) {
       const { data: batch, error } = await supabase
         .from('user_access')
         .select('clerk_user_id, progress_data, subscription_type, updated_at')
-        .not('progress_data', 'is', null)
+        .not('progress_data->completed', 'is', null)
         .order('clerk_user_id', { ascending: true })
         .range(from, from + pageSize - 1);
 

--- a/api/progress.js
+++ b/api/progress.js
@@ -54,12 +54,27 @@ export default async function handler(req, res) {
   }
 
   // POST — save progress
+  // Merge into existing progress_data so we don't clobber other top-level keys
+  // (e.g. `course_advisor` written by /api/course-advisor).
   const { completed, taskStates, notes } = req.body || {};
 
   try {
+    const { data: existing } = await supabase
+      .from('user_access')
+      .select('progress_data')
+      .eq('clerk_user_id', userId)
+      .single();
+
+    const merged = {
+      ...(existing?.progress_data || {}),
+      completed,
+      taskStates,
+      notes,
+    };
+
     await supabase
       .from('user_access')
-      .update({ progress_data: { completed, taskStates, notes }, updated_at: new Date().toISOString() })
+      .update({ progress_data: merged, updated_at: new Date().toISOString() })
       .eq('clerk_user_id', userId);
 
     return res.status(200).json({ ok: true });


### PR DESCRIPTION
## Summary

Two small fixes triggered by an investigation into 'leaderboard appears empty' and 'daily-freshness-plan workflow failing'.

## Findings

**Leaderboard:** Not actually broken. DB confirms 0 of 15 user_access rows have any completed days. Empty rendering = correct rendering of empty data.

**Sprint 2 silent regression** (real bug, fixed here): `api/progress.js` POST overwrote the entire `progress_data` JSONB on every save. Sprint 2 added a top-level `course_advisor` key (written by `/api/course-advisor`). Any quiz-taker who marked a day complete had their `course_advisor` data silently wiped. Blast radius today: 1 of 15 users; would compound with adoption.

**Cosmetic fix:** `api/leaderboard.js` filtered `progress_data IS NOT NULL` — but the column DEFAULT is `'{}'::jsonb`, so every row matches. `totalUsers` was inflated by welcome-email/upsert-created rows. Now filters on `progress_data->completed IS NOT NULL` so the count reflects actual course participants.

**Freshness workflow:** "job not acquired by Runner of type hosted" is a transient GitHub Actions infra issue. The YAML hasn't changed since `31016af` (pre-Sprint-1). Not a code regression — just rerun the workflow. Out of scope for this PR.

## Changes

- `api/progress.js` — read existing row, merge `{completed, taskStates, notes}` into existing `progress_data`, then update.
- `api/leaderboard.js` — filter on `progress_data->completed` instead of the always-true `progress_data IS NOT NULL`.

## Test plan

- POST /api/progress for a user who has `course_advisor` set → confirm `course_advisor` is preserved after the save.
- GET /api/leaderboard → `stats.totalUsers` should drop to actual participant count (currently 0 against prod DB).