### PR TITLE
feat: shared left-sidebar nav + accurate Total Learners count

### DIFF
--- a/api/leaderboard.js
+++ b/api/leaderboard.js
@@ -13,6 +13,16 @@ export default async function handler(req, res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
 
   try {
+    // Total signed-up learners (matches Clerk signup count) — independent of progress.
+    let totalUsers = 0;
+    {
+      const { count, error: cErr } = await supabase
+        .from('user_access')
+        .select('*', { count: 'exact', head: true });
+      if (cErr) throw cErr;
+      totalUsers = count || 0;
+    }
+
     // Paginated fetch to avoid loading entire table into memory
     const pageSize = 1000;
     let from = 0;
@@ -33,8 +43,7 @@ export default async function handler(req, res) {
       from += pageSize;
     }
 
-    // Aggregate stats
-    let totalUsers = allUsers.length;
+    // Aggregate stats (over participants — those with a `completed` key)
     let totalDaysCompleted = 0;
     const dayCounts = {};
 
@@ -87,10 +96,11 @@ export default async function handler(req, res) {
           const myCompleted = me.progress_data?.completed || [];
           const myCount = myCompleted.length;
 
-          // Calculate percentile rank
+          // Percentile is over fellow participants (users who have a `completed` key),
+          // not over total signups. Matches what 'percentile of learners' implies.
           const allCounts = allUsers.map(u => (u.progress_data?.completed || []).length);
           const below = allCounts.filter(c => c < myCount).length;
-          const percentile = totalUsers > 0 ? Math.round((below / totalUsers) * 100) : 0;
+          const percentile = allCounts.length > 0 ? Math.round((below / allCounts.length) * 100) : 0;
 
           // Calculate streak (consecutive days from last completed)
           const sorted = [...myCompleted].sort((a, b) => a - b);

--- a/public/ai-calculator.html
+++ b/public/ai-calculator.html
@@ -27,6 +27,7 @@
 <meta name="twitter:description" content="Compare 40+ LLM API prices in real time.">
 <meta name="twitter:image" content="https://becomeaipm.com/og-image.png">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400;500;600;700&family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,700;0,9..144,900;1,9..144,400&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/components/nav.css">
 <style>
 :root{
   --bg:#f5f0e8;--bg2:#ede8df;--ink:#1a1512;--ink2:#3d3530;--muted:#8c7f74;
@@ -36,17 +37,6 @@
 *{margin:0;padding:0;box-sizing:border-box;}
 html{font-size:16px;}
 body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;min-height:100vh;}
-
-/* NAV */
-nav{background:var(--ink);padding:0 40px;display:flex;align-items:stretch;position:sticky;top:0;z-index:100;}
-.nav-logo{font-family:'IBM Plex Mono',monospace;font-size:12px;color:var(--amber);letter-spacing:.15em;text-decoration:none;display:flex;align-items:center;padding:14px 0;margin-right:24px;}
-.nav-links{display:flex;align-items:stretch;gap:2px;flex:1;}
-.nav-link{font-family:'IBM Plex Mono',monospace;font-size:11px;color:rgba(255,255,255,.4);text-decoration:none;padding:0 14px;display:flex;align-items:center;border-bottom:2px solid transparent;transition:all .15s;white-space:nowrap;}
-.nav-link:hover{color:rgba(255,255,255,.8);border-bottom-color:rgba(255,255,255,.2);}
-.nav-link.active{color:var(--amber);border-bottom-color:var(--amber);}
-.nav-right{display:flex;align-items:center;gap:10px;padding:10px 0;margin-left:auto;}
-.nb{font-family:'IBM Plex Mono',monospace;font-size:11px;padding:5px 12px;border:1px solid rgba(255,255,255,.15);color:rgba(255,255,255,.5);background:transparent;border-radius:2px;cursor:pointer;transition:all .15s;}
-.nb:hover{border-color:var(--amber);color:var(--amber);}
 
 /* PAGE HEADER */
 .ph{padding:48px 40px 32px;border-bottom:1px solid var(--rule);background:var(--ink);}
@@ -192,21 +182,7 @@ nav{background:var(--ink);padding:0 40px;display:flex;align-items:stretch;positi
 </head>
 <body>
 
-<nav>
-  <a class="nav-logo" href="/" aria-label="becomeaipm home"><img src="/assets/becomeaipm-logo-on-dark.svg" alt="becomeaipm" height="22" style="display:block;"></a>
-  <div class="nav-links">
-    <a class="nav-link" href="/course.html">Course</a>
-    <a class="nav-link" href="/companies.html">Companies</a>
-    <a class="nav-link active" href="/ai-calculator.html">AI Calculator</a>
-    <a class="nav-link" href="/analytics.html">Leaderboard</a>
-    <a class="nav-link" href="/gaps.html">Gaps</a>
-    <a class="nav-link" href="/contact.html">Contact</a>
-    <a class="nav-link" href="/pm-os.html">PM-OS</a>
-  </div>
-  <div class="nav-right">
-    <span class="ph-stat" id="model-count-nav" style="font-family:'IBM Plex Mono',monospace;font-size:11px;color:rgba(255,255,255,.3);"></span>
-  </div>
-</nav>
+<aside id="app-nav"></aside>
 
 <div class="ph">
   <div class="ph-inner">
@@ -556,6 +532,7 @@ function showToast(msg) {
 }
 
 boot();
-</script>
+</script><script src="/components/nav.js"></script>
+<script>renderSidebar({ active: 'calculator' });</script>
 </body>
 </html>

--- a/public/ai-pm-course.html
+++ b/public/ai-pm-course.html
@@ -27,16 +27,11 @@
 <meta name="twitter:description" content="Built by a working AI PM. Hands-on. 100% free.">
 <meta name="twitter:image" content="https://becomeaipm.com/og-course.png">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Fraunces:ital,wght@0,300;0,600;0,900;1,300;1,600&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/components/nav.css">
 <style>
 :root{--bg:#f5f0e8;--bg2:#ede8df;--ink:#1a1512;--ink2:#3d3530;--muted:#8c7f74;--rule:#d4cdc4;--amber:#c8590a;--teal:#0d6e6e;--card:#faf7f2;--border:#ccc4b8;--green:#16a34a;}
 *{margin:0;padding:0;box-sizing:border-box;}
 body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;min-height:100vh;line-height:1.6;}
-nav{background:var(--ink);padding:0 40px;display:flex;align-items:stretch;position:sticky;top:0;z-index:100;}
-.nav-logo{font-family:'IBM Plex Mono',monospace;font-size:12px;color:var(--amber);letter-spacing:.15em;text-decoration:none;display:flex;align-items:center;padding:14px 0;margin-right:24px;}
-.nav-links{display:flex;align-items:stretch;gap:2px;flex:1;}
-.nav-link{font-family:'IBM Plex Mono',monospace;font-size:11px;color:rgba(255,255,255,.4);text-decoration:none;padding:0 14px;display:flex;align-items:center;border-bottom:2px solid transparent;transition:all .15s;white-space:nowrap;}
-.nav-link:hover{color:rgba(255,255,255,.8);border-bottom-color:rgba(255,255,255,.2);}
-.nav-link.active{color:var(--amber);border-bottom-color:var(--amber);}
 .hero{padding:80px 40px 60px;max-width:1000px;margin:0 auto;}
 .eyebrow{font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.18em;color:var(--amber);text-transform:uppercase;margin-bottom:18px;}
 h1{font-family:'Fraunces',serif;font-size:clamp(38px,5.5vw,68px);font-weight:900;line-height:1.05;margin-bottom:20px;}
@@ -106,17 +101,7 @@ footer a:hover{color:var(--amber);}
 </head>
 <body>
 
-<nav>
-  <a class="nav-logo" href="/" aria-label="becomeaipm home"><img src="/assets/becomeaipm-logo-on-dark.svg" alt="becomeaipm" height="22" style="display:block;"></a>
-  <div class="nav-links">
-    <a class="nav-link active" href="/ai-pm-course">AI PM Course</a>
-    <a class="nav-link" href="/course.html">Curriculum</a>
-    <a class="nav-link" href="/ai-pm-jobs">Jobs</a>
-    <a class="nav-link" href="/ai-calculator.html">AI Calculator</a>
-    <a class="nav-link" href="/pm-os.html">PM-OS</a>
-    <a class="nav-link" href="/contact.html">Contact</a>
-  </div>
-</nav>
+<aside id="app-nav"></aside>
 
 <div class="hero">
   <div class="eyebrow">The AI Product Manager Course · 60 Days · Free</div>
@@ -227,6 +212,7 @@ footer a:hover{color:var(--amber);}
 <script>
 function toggleFaq(el){el.parentElement.classList.toggle('open');}
 </script>
-
+<script src="/components/nav.js"></script>
+<script>renderSidebar({});</script>
 </body>
 </html>

--- a/public/ai-pm-jobs.html
+++ b/public/ai-pm-jobs.html
@@ -27,16 +27,11 @@
 <meta name="twitter:description" content="Live AI PM openings. Salary ranges. Updated daily.">
 <meta name="twitter:image" content="https://becomeaipm.com/og-jobs.png">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Fraunces:ital,wght@0,300;0,600;0,900&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/components/nav.css">
 <style>
 :root{--bg:#f5f0e8;--bg2:#ede8df;--ink:#1a1512;--ink2:#3d3530;--muted:#8c7f74;--rule:#d4cdc4;--amber:#c8590a;--teal:#0d6e6e;--card:#faf7f2;--border:#ccc4b8;--green:#16a34a;}
 *{margin:0;padding:0;box-sizing:border-box;}
 body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;min-height:100vh;line-height:1.65;}
-nav{background:var(--ink);padding:0 40px;display:flex;align-items:stretch;position:sticky;top:0;z-index:100;}
-.nav-logo{font-family:'IBM Plex Mono',monospace;font-size:12px;color:var(--amber);letter-spacing:.15em;text-decoration:none;display:flex;align-items:center;padding:14px 0;margin-right:24px;}
-.nav-links{display:flex;align-items:stretch;gap:2px;flex:1;}
-.nav-link{font-family:'IBM Plex Mono',monospace;font-size:11px;color:rgba(255,255,255,.4);text-decoration:none;padding:0 14px;display:flex;align-items:center;border-bottom:2px solid transparent;transition:all .15s;white-space:nowrap;}
-.nav-link:hover{color:rgba(255,255,255,.8);border-bottom-color:rgba(255,255,255,.2);}
-.nav-link.active{color:var(--amber);border-bottom-color:var(--amber);}
 .hero{padding:80px 40px 40px;max-width:1000px;margin:0 auto;}
 .eyebrow{font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.18em;color:var(--amber);text-transform:uppercase;margin-bottom:18px;}
 .live-dot{display:inline-flex;align-items:center;gap:6px;background:var(--ink);padding:3px 11px;border-radius:20px;margin-left:10px;}
@@ -105,17 +100,7 @@ a.inline:hover{color:var(--amber);border-bottom-color:var(--amber);}
 </head>
 <body>
 
-<nav>
-  <a class="nav-logo" href="/" aria-label="becomeaipm home"><img src="/assets/becomeaipm-logo-on-dark.svg" alt="becomeaipm" height="22" style="display:block;"></a>
-  <div class="nav-links">
-    <a class="nav-link" href="/ai-pm-course">AI PM Course</a>
-    <a class="nav-link" href="/how-to-become-ai-pm">Guide</a>
-    <a class="nav-link active" href="/ai-pm-jobs">Jobs</a>
-    <a class="nav-link" href="/ai-calculator.html">AI Calculator</a>
-    <a class="nav-link" href="/pm-os.html">PM-OS</a>
-    <a class="nav-link" href="/contact.html">Contact</a>
-  </div>
-</nav>
+<aside id="app-nav"></aside>
 
 <div class="hero">
   <div class="eyebrow">AI PM Jobs Tracker <span class="live-dot"><span class="ldot"></span><span class="ltxt">LIVE</span></span></div>
@@ -232,7 +217,8 @@ a.inline:hover{color:var(--amber);border-bottom-color:var(--amber);}
 
 <script>
 function toggleFaq(el){el.parentElement.classList.toggle('open');}
-</script>
+</script><script src="/components/nav.js"></script>
+<script>renderSidebar({ active: 'jobs' });</script>
 
 </body>
 </html>

--- a/public/analytics.html
+++ b/public/analytics.html
@@ -22,6 +22,7 @@
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://becomeaipm.com/og-image.png">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Fraunces:ital,wght@0,300;0,600;0,900;1,300;1,600&family=DM+Sans:wght@300;400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/components/nav.css">
 <!-- Pendo Analytics (initialized after Clerk auth loads) -->
 <style>
 :root{
@@ -30,18 +31,6 @@
 }
 *{margin:0;padding:0;box-sizing:border-box;}
 body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;min-height:100vh;}
-nav{background:var(--ink);padding:0 40px;display:flex;align-items:stretch;position:sticky;top:0;z-index:100;}
-.nav-logo{font-family:'IBM Plex Mono',monospace;font-size:12px;color:var(--amber);letter-spacing:.15em;text-decoration:none;display:flex;align-items:center;padding:14px 0;margin-right:24px;white-space:nowrap;}
-.nav-links{display:flex;align-items:stretch;gap:2px;flex:1;}
-.nav-link{font-family:'IBM Plex Mono',monospace;font-size:11px;color:rgba(255,255,255,.4);text-decoration:none;padding:0 14px;display:flex;align-items:center;border-bottom:2px solid transparent;transition:all .15s;white-space:nowrap;}
-.nav-link:hover{color:rgba(255,255,255,.8);border-bottom-color:rgba(255,255,255,.2);}
-.nav-link.active{color:var(--amber);border-bottom-color:var(--amber);}
-.nav-right{display:flex;align-items:center;gap:10px;padding:10px 0;margin-left:auto;}
-.nav-avatar{width:26px;height:26px;border-radius:50%;background:var(--amber);color:white;font-size:10px;font-weight:700;display:flex;align-items:center;justify-content:center;font-family:'IBM Plex Mono',monospace;}
-.nav-signout{font-family:'IBM Plex Mono',monospace;font-size:10px;color:rgba(255,255,255,.3);background:none;border:none;cursor:pointer;padding:4px 8px;}
-.nav-signout:hover{color:var(--amber);}
-.nav-signin{font-family:'IBM Plex Mono',monospace;font-size:11px;color:rgba(255,255,255,.4);background:none;border:1px solid rgba(255,255,255,.15);border-radius:2px;padding:4px 12px;cursor:pointer;transition:all .15s;text-decoration:none;}
-.nav-signin:hover{color:var(--amber);border-color:var(--amber);}
 .hero{padding:60px 40px 40px;max-width:1100px;margin:0 auto;}
 .label{font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.18em;color:var(--amber);text-transform:uppercase;margin-bottom:16px;}
 h1{font-family:'Fraunces',serif;font-size:clamp(30px,4.5vw,56px);font-weight:900;line-height:1.05;margin-bottom:14px;}
@@ -104,19 +93,7 @@ footer a:hover{color:var(--amber);}
 </head>
 <body>
 
-<nav>
-  <a class="nav-logo" href="/" aria-label="becomeaipm home"><img src="/assets/becomeaipm-logo-on-dark.svg" alt="becomeaipm" height="22" style="display:block;"></a>
-  <div class="nav-links">
-    <a class="nav-link" href="/course.html">Course</a>
-    <a class="nav-link" href="/companies.html">Companies</a>
-    <a class="nav-link" href="/ai-calculator.html">AI Calculator</a>
-    <a class="nav-link active" href="/analytics.html">Leaderboard</a>
-    <a class="nav-link" href="/gaps.html">Gaps</a>
-    <a class="nav-link" href="/contact.html">Contact</a>
-    <a class="nav-link" href="/pm-os.html">PM-OS</a>
-    <a class="nav-link" href="/settings.html">Settings</a>
-  </div>
-</nav>
+<aside id="app-nav"></aside>
 
 <div class="hero">
   <div class="label">Community Progress</div>
@@ -177,7 +154,7 @@ footer a:hover{color:var(--amber);}
 <footer><p>&copy; 2025 becomeaipm.com &middot; <a href="/">Home</a> &middot; <a href="mailto:hello@becomeaipm.com">hello@becomeaipm.com</a></p></footer>
 
 <script>
-function updateAuthUI(){var user=window.Clerk&&window.Clerk.user;var nu=document.getElementById('nav-user');var ns=document.getElementById('nav-signin');var na=document.getElementById('nav-avatar');if(nu)nu.style.display=user?'flex':'none';if(ns)ns.style.display=user?'none':'inline-block';if(user&&na){na.textContent=(user.firstName?.[0]||user.emailAddresses?.[0]?.emailAddress?.[0]||'?').toUpperCase();}}
+function updateAuthUI(){}
 async function doSignOut(){if(window.Clerk){await window.Clerk.signOut();updateAuthUI();}}
 function openSignIn(){if(!window.Clerk){location.href='/course.html';return;}window.Clerk.openSignIn({fallbackRedirectUrl:window.location.href,signUpFallbackRedirectUrl:'/course.html'});}
 var cfg=null;
@@ -235,6 +212,7 @@ function canUsePendo(){return localStorage.getItem('cookie_consent')==='accepted
   <button class="cookie-btn cookie-accept" onclick="acceptCookies()">Accept</button>
   <button class="cookie-btn cookie-decline" onclick="declineCookies()">Decline</button>
 </div>
+<script src="/components/nav.js"></script>
+<script>renderSidebar({ active: 'leaderboard' });</script>
 
 </body>
-</html>

--- a/public/companies.html
+++ b/public/companies.html
@@ -27,21 +27,11 @@
 <meta name="twitter:description" content="Live PM roles at Anthropic, OpenAI, Scale, Mistral, Cohere. Updated daily.">
 <meta name="twitter:image" content="https://becomeaipm.com/og-companies.png">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Fraunces:ital,wght@0,600;0,900&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/components/nav.css">
 <!-- Pendo Analytics (initialized after Clerk auth loads) -->
 <style>
 :root{--bg:#f5f0e8;--bg2:#ede8df;--ink:#1a1512;--ink2:#3d3530;--muted:#8c7f74;--border:#ccc4b8;--card:#faf7f2;--amber:#c8590a;--teal:#0d6e6e;--rule:#d4cdc4;--green:#16a34a;--purple:#7c3aed;}
 *{margin:0;padding:0;box-sizing:border-box;}body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;min-height:100vh;}
-nav{background:var(--ink);padding:0 40px;display:flex;align-items:stretch;position:sticky;top:0;z-index:200;}
-.nav-logo{font-family:'IBM Plex Mono',monospace;font-size:12px;color:var(--amber);letter-spacing:.15em;text-decoration:none;display:flex;align-items:center;padding:14px 0;margin-right:24px;white-space:nowrap;}
-.nav-links{display:flex;align-items:stretch;gap:2px;flex:1;}
-.nav-link{font-family:'IBM Plex Mono',monospace;font-size:11px;color:rgba(255,255,255,.4);text-decoration:none;padding:0 14px;display:flex;align-items:center;border-bottom:2px solid transparent;transition:all .15s;white-space:nowrap;}
-.nav-link:hover{color:rgba(255,255,255,.8);border-bottom-color:rgba(255,255,255,.2);}
-.nav-link.active{color:var(--amber);border-bottom-color:var(--amber);}
-.nav-right{display:flex;align-items:center;gap:10px;padding:10px 0;margin-left:auto;}
-.nav-user{display:flex;align-items:center;gap:8px;}
-.nav-avatar{width:26px;height:26px;border-radius:50%;background:var(--amber);color:white;font-size:10px;font-weight:700;display:flex;align-items:center;justify-content:center;font-family:'IBM Plex Mono',monospace;}
-.nav-signout{font-family:'IBM Plex Mono',monospace;font-size:10px;color:rgba(255,255,255,.3);background:none;border:none;cursor:pointer;padding:4px 8px;}
-.nav-signout:hover{color:var(--amber);}
 .overlay{display:none;position:fixed;inset:0;background:rgba(0,0,0,.7);z-index:1000;align-items:center;justify-content:center;backdrop-filter:blur(4px);}
 .overlay.open{display:flex;}
 .clerk-wrap{position:relative;max-width:480px;width:90%;}
@@ -158,7 +148,7 @@ h1 em{color:var(--amber);font-style:italic;}
 .saved-txt{font-family:'IBM Plex Mono',monospace;font-size:11px;color:var(--amber);}
 .saved-clear{font-family:'IBM Plex Mono',monospace;font-size:10px;color:var(--muted);background:none;border:none;cursor:pointer;margin-left:auto;}
 .saved-clear:hover{color:var(--amber);}
-@media(max-width:768px){nav{padding:12px 20px;}.hero,.grid-area{padding-left:20px;padding-right:20px;}.controls{padding:12px 20px;top:53px;}.drawer{width:100vw;}}
+@media(max-width:768px){.hero,.grid-area{padding-left:20px;padding-right:20px;}.controls{padding:12px 20px;top:53px;}.drawer{width:100vw;}}
 .cookie-banner{display:none;position:fixed;bottom:0;left:0;right:0;background:var(--ink);padding:16px 40px;z-index:9999;align-items:center;justify-content:center;gap:16px;flex-wrap:wrap;}
 .cookie-banner.show{display:flex;}
 .cookie-text{font-family:'IBM Plex Mono',monospace;font-size:12px;color:rgba(255,255,255,.6);line-height:1.6;flex:1;min-width:200px;}
@@ -182,23 +172,7 @@ h1 em{color:var(--amber);font-style:italic;}
   </div>
 </div>
 
-<nav id="main-nav">
-  <a class="nav-logo" href="/" aria-label="becomeaipm home"><img src="/assets/becomeaipm-logo-on-dark.svg" alt="becomeaipm" height="22" style="display:block;"></a>
-  <div class="nav-links">
-    <a class="nav-link" href="/course.html">Course</a>
-    <a class="nav-link active" href="/companies.html">Companies</a>
-    <a class="nav-link" href="/ai-calculator.html">AI Calculator</a>
-    <a class="nav-link" href="/analytics.html">Leaderboard</a>
-    <a class="nav-link" href="/gaps.html">Gaps</a>
-    <a class="nav-link" href="/contact.html">Contact</a>
-    <a class="nav-link" href="/pm-os.html">PM-OS</a>
-    <a class="nav-link" href="/settings.html">Settings</a>
-      <div class="nav-avatar" id="nav-avatar">?</div>
-      <button class="nav-signout" onclick="doSignOut()">Sign Out</button>
-    </div>
-    <a class="nav-link" id="signin-pill" href="#" onclick="openSignIn();return false;" style="display:none">Sign In</a>
-  </div>
-</nav>
+<aside id="app-nav"></aside>
 
 <div id="saved-banner" class="saved-banner">
   <span class="saved-txt" id="saved-txt">0 roles saved</span>
@@ -276,8 +250,8 @@ let saved=JSON.parse(localStorage.getItem('saved_roles')||'{}');
     s.onerror=()=>{loadCompanies();updateAuthUI();};
   }catch(e){loadCompanies();updateAuthUI();}
 })();
-function updateAuthUI(){const nu=document.getElementById('nav-user');const sp=document.getElementById('signin-pill');const av=document.getElementById('nav-avatar');if(user){if(av)av.textContent=(user.firstName?.[0]||user.emailAddresses?.[0]?.emailAddress?.[0]||'?').toUpperCase();if(nu)nu.style.display='flex';if(sp)sp.style.display='none';}else{if(nu)nu.style.display='none';if(sp)sp.style.display='inline-flex';}}
-async function doSignOut(){await clerk?.signOut();user=null;updateAuthUI();}
+function updateAuthUI(){}
+async function doSignOut(){await clerk?.signOut();user=null;}
 function openSignIn(){document.getElementById('overlay').classList.add('open');if(!clerkMounted&&clerk){const el=document.getElementById('clerk-mount');el.innerHTML='';clerk.mountSignIn(el,{routing:'hash'});clerkMounted=true;}}
 function closeSignIn(){document.getElementById('overlay').classList.remove('open');if(clerkMounted&&clerk){try{clerk.unmountSignIn(document.getElementById('clerk-mount'));}catch(e){}clerkMounted=false;}}
 document.getElementById('overlay').addEventListener('click',e=>{if(e.target===document.getElementById('overlay'))closeSignIn();});
@@ -330,6 +304,8 @@ function canUsePendo(){return localStorage.getItem('cookie_consent')==='accepted
   </ul>
   <p style="margin-top:24px;font-size:13px;color:var(--muted);font-family:'IBM Plex Mono',monospace;">Last reviewed April 2026 by <a href="https://www.linkedin.com/in/stavanmehta/" target="_blank" rel="noopener" style="color:var(--amber);">Stavan Mehta</a> — <a href="/contact.html" style="color:var(--amber);">send feedback</a></p>
 </section>
+<script src="/components/nav.js"></script>
+<script>renderSidebar({ active: 'companies' });</script>
 
 </body>
 </html>

--- a/public/components/nav.css
+++ b/public/components/nav.css
@@ -1,0 +1,156 @@
+/* Shared left-sidebar navigation. Scoped to #app-nav. */
+:root {
+  --nav-w-expanded: 230px;
+  --nav-w-collapsed: 56px;
+  --nav-bg: #1a1512;
+  --nav-fg: rgba(255,255,255,.65);
+  --nav-fg-dim: rgba(255,255,255,.4);
+  --nav-fg-bright: rgba(255,255,255,.95);
+  --nav-amber: #c8590a;
+  --nav-rule: rgba(255,255,255,.08);
+}
+
+#app-nav {
+  position: fixed;
+  top: 0; left: 0; bottom: 0;
+  width: var(--nav-w-expanded);
+  background: var(--nav-bg);
+  color: var(--nav-fg);
+  font-family: 'IBM Plex Mono', monospace;
+  display: flex;
+  flex-direction: column;
+  z-index: 100;
+  transition: width .18s ease;
+  overflow: hidden;
+}
+#app-nav.collapsed { width: var(--nav-w-collapsed); }
+
+body.has-app-nav { padding-left: var(--nav-w-expanded); transition: padding-left .18s ease; }
+body.has-app-nav.nav-collapsed { padding-left: var(--nav-w-collapsed); }
+
+#app-nav .nav-brand {
+  display: flex; align-items: center; gap: 10px;
+  padding: 16px 18px 14px; border-bottom: 1px solid var(--nav-rule);
+  text-decoration: none; color: var(--nav-amber);
+  font-size: 12px; letter-spacing: .14em;
+  white-space: nowrap;
+}
+#app-nav .nav-brand img { height: 20px; flex: 0 0 auto; }
+#app-nav .nav-brand .brand-text { font-weight: 700; }
+#app-nav.collapsed .nav-brand { padding: 16px 14px; justify-content: center; }
+#app-nav.collapsed .nav-brand .brand-text { display: none; }
+
+#app-nav .nav-toggle {
+  position: absolute; top: 14px; right: -12px;
+  width: 24px; height: 24px; border-radius: 50%;
+  background: var(--nav-bg); color: var(--nav-fg-dim);
+  border: 1px solid var(--nav-rule); cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 14px; padding: 0; line-height: 1;
+  transition: color .15s, transform .18s;
+}
+#app-nav .nav-toggle:hover { color: var(--nav-amber); }
+#app-nav.collapsed .nav-toggle { transform: rotate(180deg); }
+
+#app-nav .nav-scroll {
+  flex: 1 1 auto; overflow-y: auto; overflow-x: hidden;
+  padding: 12px 0;
+}
+#app-nav .nav-scroll::-webkit-scrollbar { width: 4px; }
+#app-nav .nav-scroll::-webkit-scrollbar-thumb { background: rgba(255,255,255,.08); border-radius: 2px; }
+
+#app-nav .nav-group { margin: 0 0 6px; }
+#app-nav .nav-group-label {
+  display: block;
+  padding: 14px 18px 6px;
+  font-size: 9px; letter-spacing: .22em; text-transform: uppercase;
+  color: var(--nav-fg-dim);
+  white-space: nowrap; overflow: hidden;
+}
+#app-nav.collapsed .nav-group-label {
+  font-size: 0; padding: 12px 0 4px; height: 1px;
+  background: var(--nav-rule); margin: 8px 14px;
+  letter-spacing: 0;
+}
+
+#app-nav .nav-item {
+  display: flex; align-items: center; gap: 12px;
+  padding: 9px 18px;
+  color: var(--nav-fg); text-decoration: none;
+  font-size: 12px;
+  border-left: 2px solid transparent;
+  transition: color .12s, background .12s, border-color .12s;
+  white-space: nowrap;
+}
+#app-nav .nav-item:hover { color: var(--nav-fg-bright); background: rgba(255,255,255,.03); }
+#app-nav .nav-item.active {
+  color: var(--nav-amber);
+  border-left-color: var(--nav-amber);
+  background: rgba(200,89,10,.08);
+}
+#app-nav .nav-item .nav-icon {
+  flex: 0 0 20px; width: 20px; height: 20px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 14px;
+}
+#app-nav.collapsed .nav-item { padding: 10px 0; justify-content: center; }
+#app-nav.collapsed .nav-item .nav-label { display: none; }
+
+#app-nav .nav-bottom {
+  border-top: 1px solid var(--nav-rule);
+  padding: 10px 0;
+}
+#app-nav .nav-user {
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 18px;
+  border-left: 2px solid transparent;
+}
+#app-nav .nav-avatar {
+  width: 26px; height: 26px; border-radius: 50%;
+  background: var(--nav-amber); color: #fff;
+  font-size: 11px; font-weight: 700;
+  display: flex; align-items: center; justify-content: center;
+  flex: 0 0 26px;
+}
+#app-nav .nav-uname {
+  font-size: 11px; color: var(--nav-fg);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  flex: 1 1 auto;
+}
+#app-nav .nav-signout, #app-nav .nav-signin {
+  display: block; margin: 6px 14px; padding: 7px 12px;
+  font-family: 'IBM Plex Mono', monospace; font-size: 10px; letter-spacing: .14em;
+  text-align: center; text-decoration: none; cursor: pointer;
+  background: transparent; color: var(--nav-fg-dim);
+  border: 1px solid var(--nav-rule); border-radius: 3px;
+  transition: color .12s, border-color .12s;
+}
+#app-nav .nav-signout:hover, #app-nav .nav-signin:hover {
+  color: var(--nav-amber); border-color: var(--nav-amber);
+}
+#app-nav.collapsed .nav-uname,
+#app-nav.collapsed .nav-signout,
+#app-nav.collapsed .nav-signin { display: none; }
+#app-nav.collapsed .nav-user { justify-content: center; padding: 10px 0; }
+
+/* Mobile */
+#app-nav-hamburger {
+  display: none;
+  position: fixed; top: 12px; left: 12px; z-index: 101;
+  width: 36px; height: 36px; border-radius: 4px;
+  background: var(--nav-bg); color: #fff;
+  border: 1px solid var(--nav-rule); cursor: pointer;
+  font-size: 18px; line-height: 1; padding: 0;
+}
+#app-nav-backdrop {
+  display: none; position: fixed; inset: 0;
+  background: rgba(0,0,0,.5); z-index: 99;
+}
+@media (max-width: 768px) {
+  body.has-app-nav { padding-left: 0; }
+  #app-nav { transform: translateX(-100%); width: 240px; }
+  #app-nav.mobile-open { transform: translateX(0); }
+  #app-nav .nav-toggle { display: none; }
+  #app-nav-hamburger { display: flex; align-items: center; justify-content: center; }
+  body.has-app-nav.mobile-open #app-nav-backdrop { display: block; }
+}

--- a/public/components/nav.js
+++ b/public/components/nav.js
@@ -1,0 +1,202 @@
+/* Shared sidebar nav. Usage:
+ *   <link rel="stylesheet" href="/components/nav.css">
+ *   <aside id="app-nav"></aside>
+ *   <script src="/components/nav.js"></script>
+ *   <script>renderSidebar({ active: 'leaderboard' });</script>
+ *
+ * `active` is one of the item keys in NAV_ITEMS below. When omitted, no item is highlighted.
+ */
+(function () {
+  var GROUPS = [
+    {
+      label: 'Learn',
+      items: [
+        { key: 'course',    href: '/course.html',              label: '60-Day AI PM',  icon: '\u25A0' }
+      ]
+    },
+    {
+      label: 'PM Toolkit',
+      items: [
+        { key: 'calculator', href: '/ai-calculator.html',      label: 'AI Calculator', icon: '\u00A4' }
+      ]
+    },
+    {
+      label: 'Discover',
+      items: [
+        { key: 'companies',  href: '/companies.html',          label: 'Companies',     icon: '\u25CE' },
+        { key: 'jobs',       href: '/ai-pm-jobs.html',         label: 'AI PM Jobs',    icon: '\u25B8' },
+        { key: 'gaps',       href: '/gaps.html',               label: 'Content Gaps',  icon: '\u25B3' },
+        { key: 'how-to',     href: '/how-to-become-ai-pm.html',label: 'How-To',        icon: '?' },
+        { key: 'pm-os',      href: '/pm-os.html',              label: 'PM-OS',         icon: '\u25C7' }
+      ]
+    },
+    {
+      label: 'Community',
+      items: [
+        { key: 'leaderboard', href: '/analytics.html',         label: 'Leaderboard',   icon: '\u2630' },
+        { key: 'contact',     href: '/contact.html',           label: 'Contact',       icon: '@' }
+      ]
+    }
+  ];
+
+  function escHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  function buildHtml(activeKey) {
+    var groupsHtml = GROUPS.map(function (g) {
+      var items = g.items.map(function (it) {
+        var cls = 'nav-item' + (it.key === activeKey ? ' active' : '');
+        var aria = it.key === activeKey ? ' aria-current="page"' : '';
+        return '<a class="' + cls + '" href="' + escHtml(it.href) + '"' + aria + '>'
+          + '<span class="nav-icon" aria-hidden="true">' + escHtml(it.icon) + '</span>'
+          + '<span class="nav-label">' + escHtml(it.label) + '</span></a>';
+      }).join('');
+      return '<div class="nav-group">'
+        + '<span class="nav-group-label">' + escHtml(g.label) + '</span>'
+        + items + '</div>';
+    }).join('');
+
+    var settingsActive = activeKey === 'settings' ? ' active' : '';
+    var settingsAria = activeKey === 'settings' ? ' aria-current="page"' : '';
+
+    return ''
+      + '<a class="nav-brand" href="/" aria-label="becomeaipm home">'
+      +   '<img src="/assets/becomeaipm-logo-on-dark.svg" alt="" />'
+      +   '<span class="brand-text">becomeaipm</span>'
+      + '</a>'
+      + '<button class="nav-toggle" type="button" aria-label="Collapse sidebar" data-nav-toggle>&#x276E;</button>'
+      + '<div class="nav-scroll">'
+      +   groupsHtml
+      + '</div>'
+      + '<div class="nav-bottom">'
+      +   '<a class="nav-item' + settingsActive + '" href="/settings.html"' + settingsAria + '>'
+      +     '<span class="nav-icon" aria-hidden="true">&#9881;</span>'
+      +     '<span class="nav-label">Settings</span></a>'
+      +   '<div class="nav-user" data-nav-user style="display:none">'
+      +     '<div class="nav-avatar" data-nav-avatar>?</div>'
+      +     '<span class="nav-uname" data-nav-uname></span>'
+      +   '</div>'
+      +   '<a class="nav-signin" href="#" data-nav-signin style="display:none">Sign In</a>'
+      +   '<a class="nav-signout" href="#" data-nav-signout style="display:none">Sign Out</a>'
+      + '</div>';
+  }
+
+  function applyAuth(root) {
+    var user = (window.Clerk && window.Clerk.user) || null;
+    var box  = root.querySelector('[data-nav-user]');
+    var av   = root.querySelector('[data-nav-avatar]');
+    var nm   = root.querySelector('[data-nav-uname]');
+    var so   = root.querySelector('[data-nav-signout]');
+    var si   = root.querySelector('[data-nav-signin]');
+    if (user) {
+      var initial = (user.firstName && user.firstName[0])
+        || (user.emailAddresses && user.emailAddresses[0] && user.emailAddresses[0].emailAddress && user.emailAddresses[0].emailAddress[0])
+        || '?';
+      var displayName = user.firstName || (user.emailAddresses && user.emailAddresses[0] && user.emailAddresses[0].emailAddress) || '';
+      if (av) av.textContent = String(initial).toUpperCase();
+      if (nm) nm.textContent = displayName;
+      if (box) box.style.display = 'flex';
+      if (so) so.style.display = 'block';
+      if (si) si.style.display = 'none';
+    } else {
+      if (box) box.style.display = 'none';
+      if (so) so.style.display = 'none';
+      if (si) si.style.display = 'block';
+    }
+  }
+
+  function pollClerk(root) {
+    if (window.Clerk && window.Clerk.user !== undefined) {
+      applyAuth(root);
+      try { window.Clerk.addListener && window.Clerk.addListener(function () { applyAuth(root); }); } catch (_e) {}
+      return;
+    }
+    setTimeout(function () { pollClerk(root); }, 250);
+  }
+
+  function setCollapsed(collapsed) {
+    var root = document.getElementById('app-nav');
+    if (!root) return;
+    if (collapsed) {
+      root.classList.add('collapsed');
+      document.body.classList.add('nav-collapsed');
+    } else {
+      root.classList.remove('collapsed');
+      document.body.classList.remove('nav-collapsed');
+    }
+    try { localStorage.setItem('navCollapsed', collapsed ? '1' : '0'); } catch (_e) {}
+  }
+
+  function setMobileOpen(open) {
+    var root = document.getElementById('app-nav');
+    if (!root) return;
+    if (open) {
+      root.classList.add('mobile-open');
+      document.body.classList.add('mobile-open');
+    } else {
+      root.classList.remove('mobile-open');
+      document.body.classList.remove('mobile-open');
+    }
+  }
+
+  window.renderSidebar = function (opts) {
+    var active = (opts && opts.active) || null;
+    var root = document.getElementById('app-nav');
+    if (!root) return;
+
+    root.innerHTML = buildHtml(active);
+    document.body.classList.add('has-app-nav');
+
+    var savedCollapsed = false;
+    try { savedCollapsed = localStorage.getItem('navCollapsed') === '1'; } catch (_e) {}
+    setCollapsed(savedCollapsed);
+
+    if (!document.getElementById('app-nav-hamburger')) {
+      var hb = document.createElement('button');
+      hb.id = 'app-nav-hamburger';
+      hb.type = 'button';
+      hb.setAttribute('aria-label', 'Open menu');
+      hb.innerHTML = '&#9776;';
+      hb.addEventListener('click', function () { setMobileOpen(true); });
+      document.body.appendChild(hb);
+
+      var bd = document.createElement('div');
+      bd.id = 'app-nav-backdrop';
+      bd.addEventListener('click', function () { setMobileOpen(false); });
+      document.body.appendChild(bd);
+    }
+
+    var toggle = root.querySelector('[data-nav-toggle]');
+    if (toggle) {
+      toggle.addEventListener('click', function () {
+        setCollapsed(!root.classList.contains('collapsed'));
+      });
+    }
+
+    var so = root.querySelector('[data-nav-signout]');
+    if (so) so.addEventListener('click', function (e) {
+      e.preventDefault();
+      if (window.Clerk && window.Clerk.signOut) {
+        window.Clerk.signOut().then(function () { applyAuth(root); });
+      }
+    });
+    var si = root.querySelector('[data-nav-signin]');
+    if (si) si.addEventListener('click', function (e) {
+      e.preventDefault();
+      if (window.Clerk && window.Clerk.openSignIn) {
+        window.Clerk.openSignIn({
+          fallbackRedirectUrl: window.location.href,
+          signUpFallbackRedirectUrl: '/course.html'
+        });
+      } else {
+        window.location.href = '/course.html';
+      }
+    });
+
+    applyAuth(root);
+    pollClerk(root);
+  };
+})();

--- a/public/contact.html
+++ b/public/contact.html
@@ -22,6 +22,7 @@
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://becomeaipm.com/og-image.png">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Fraunces:ital,wght@0,300;0,600;0,900;1,300;1,600&family=DM+Sans:wght@300;400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/components/nav.css">
 <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit" async defer></script>
 <style>
 :root{
@@ -31,18 +32,6 @@
 }
 *{margin:0;padding:0;box-sizing:border-box;}
 body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;min-height:100vh;}
-nav{background:var(--ink);padding:0 40px;display:flex;align-items:stretch;position:sticky;top:0;z-index:100;}
-.nav-logo{font-family:'IBM Plex Mono',monospace;font-size:12px;color:var(--amber);letter-spacing:.15em;text-decoration:none;display:flex;align-items:center;padding:14px 0;margin-right:24px;white-space:nowrap;}
-.nav-links{display:flex;align-items:stretch;gap:2px;flex:1;}
-.nav-link{font-family:'IBM Plex Mono',monospace;font-size:11px;color:rgba(255,255,255,.4);text-decoration:none;padding:0 14px;display:flex;align-items:center;border-bottom:2px solid transparent;transition:all .15s;white-space:nowrap;}
-.nav-link:hover{color:rgba(255,255,255,.8);border-bottom-color:rgba(255,255,255,.2);}
-.nav-link.active{color:var(--amber);border-bottom-color:var(--amber);}
-.nav-right{display:flex;align-items:center;gap:10px;padding:10px 0;margin-left:auto;}
-.nav-avatar{width:26px;height:26px;border-radius:50%;background:var(--amber);color:white;font-size:10px;font-weight:700;display:flex;align-items:center;justify-content:center;font-family:'IBM Plex Mono',monospace;}
-.nav-signout{font-family:'IBM Plex Mono',monospace;font-size:10px;color:rgba(255,255,255,.3);background:none;border:none;cursor:pointer;padding:4px 8px;}
-.nav-signout:hover{color:var(--amber);}
-.nav-signin{font-family:'IBM Plex Mono',monospace;font-size:11px;color:rgba(255,255,255,.4);background:none;border:1px solid rgba(255,255,255,.15);border-radius:2px;padding:4px 12px;cursor:pointer;transition:all .15s;}
-.nav-signin:hover{color:var(--amber);border-color:var(--amber);}
 .hero{padding:80px 40px 60px;max-width:900px;margin:0 auto;}
 .label{font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.18em;color:var(--amber);text-transform:uppercase;margin-bottom:20px;}
 h1{font-family:'Fraunces',serif;font-size:clamp(36px,5vw,64px);font-weight:900;line-height:1.05;margin-bottom:20px;}
@@ -97,26 +86,7 @@ footer a:hover{color:var(--amber);}
 </head>
 <body>
 
-<nav>
-  <a class="nav-logo" href="/" aria-label="becomeaipm home"><img src="/assets/becomeaipm-logo-on-dark.svg" alt="becomeaipm" height="22" style="display:block;"></a>
-  <div class="nav-links">
-    <a class="nav-link" href="/course.html">Course</a>
-    <a class="nav-link" href="/companies.html">Companies</a>
-    <a class="nav-link" href="/ai-calculator.html">AI Calculator</a>
-    <a class="nav-link" href="/analytics.html">Leaderboard</a>
-    <a class="nav-link" href="/gaps.html">Gaps</a>
-    <a class="nav-link active" href="/contact.html">Contact</a>
-    <a class="nav-link" href="/pm-os.html">PM-OS</a>
-    <a class="nav-link" href="/settings.html">Settings</a>
-  </div>
-  <div class="nav-right">
-    <div id="nav-user" style="display:none">
-      <div class="nav-avatar" id="nav-avatar">?</div>
-      <button class="nav-signout" onclick="doSignOut()">Sign Out</button>
-    </div>
-    <a class="nav-signin" id="nav-signin" href="/course.html" style="display:none">Sign In</a>
-  </div>
-</nav>
+<aside id="app-nav"></aside>
 
 <div class="hero">
   <div class="label">Support &amp; Feedback</div>
@@ -179,7 +149,7 @@ footer a:hover{color:var(--amber);}
 
 <script>
 var turnstileSiteKey='';var clerk=null;var contactCfg=null;
-function updateAuthUI(){var user=clerk&&clerk.user;document.getElementById('nav-user').style.display=user?'flex':'none';document.getElementById('nav-signin').style.display=user?'none':'inline-block';if(user){var init=(user.firstName?.[0]||user.emailAddresses?.[0]?.emailAddress?.[0]||'?').toUpperCase();document.getElementById('nav-avatar').textContent=init;}}
+function updateAuthUI(){}
 async function doSignOut(){if(clerk){await clerk.signOut();updateAuthUI();}}
 (async function initContactPage(){
   try{
@@ -220,6 +190,7 @@ function canUsePendo(){return localStorage.getItem('cookie_consent')==='accepted
   <button class="cookie-btn cookie-accept" onclick="acceptCookies()">Accept</button>
   <button class="cookie-btn cookie-decline" onclick="declineCookies()">Decline</button>
 </div>
+<script src="/components/nav.js"></script>
+<script>renderSidebar({ active: 'contact' });</script>
 
 </body>
-</html>

--- a/public/course.html
+++ b/public/course.html
@@ -28,6 +28,8 @@
 <meta name="twitter:image" content="https://becomeaipm.com/og-image.png">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Fraunces:ital,wght@0,600;0,900&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <!-- Pendo Analytics (initialized after Clerk auth loads) -->
+<link rel="stylesheet" href="/components/nav.css">
+<style>body.has-app-nav .sidebar, body.has-app-nav #sidebar { left: var(--nav-w-expanded); transition: left .18s ease; } body.has-app-nav.nav-collapsed .sidebar, body.has-app-nav.nav-collapsed #sidebar { left: var(--nav-w-collapsed); } @media (max-width: 768px) { body.has-app-nav .sidebar, body.has-app-nav #sidebar { left: 0; } }</style>
 <style>
 :root{--bg:#f5f0e8;--ink:#1a1512;--ink2:#3d3530;--muted:#8c7f74;--border:#ccc4b8;--card:#faf7f2;--amber:#c8590a;--teal:#0d6e6e;--rule:#d4cdc4;}
 *{margin:0;padding:0;box-sizing:border-box;}
@@ -40,20 +42,7 @@ body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;disp
 .ld-err{color:#f87171;font-size:14px;text-align:center;max-width:400px;line-height:1.7;display:none;}
 .ld-err a{color:#fca87a;text-decoration:underline;cursor:pointer;}
 @keyframes spin{to{transform:rotate(360deg);}}
-#topbar{background:var(--ink);padding:0 32px;display:flex;align-items:stretch;position:sticky;top:0;z-index:100;flex-shrink:0;}
-.nav-logo{font-family:'IBM Plex Mono',monospace;font-size:12px;color:#c8590a;letter-spacing:.15em;text-decoration:none;display:flex;align-items:center;padding:14px 0;margin-right:24px;white-space:nowrap;}
-.nav-links{display:flex;align-items:stretch;gap:2px;flex:1;}
-.nav-link{font-family:'IBM Plex Mono',monospace;font-size:11px;color:rgba(255,255,255,.4);text-decoration:none;padding:0 14px;display:flex;align-items:center;border-bottom:2px solid transparent;transition:all .15s;white-space:nowrap;}
-.nav-link:hover{color:rgba(255,255,255,.8);border-bottom-color:rgba(255,255,255,.2);}
-.nav-link.active{color:#c8590a;border-bottom-color:#c8590a;}
-.nav-right{display:flex;align-items:center;gap:12px;padding:10px 0;margin-left:auto;}
-.tb-day-label{font-family:'IBM Plex Mono',monospace;font-size:11px;color:rgba(255,255,255,.3);}
-.tb-streak{font-family:'IBM Plex Mono',monospace;font-size:11px;color:rgba(255,255,255,.4);display:flex;align-items:center;gap:6px;}
-.streak-fire{font-size:14px;}
-.tb-avatar{width:28px;height:28px;border-radius:50%;background:#c8590a;color:white;font-size:11px;font-weight:700;display:flex;align-items:center;justify-content:center;}
-.tb-signout{background:none;border:1px solid rgba(255,255,255,.15);color:rgba(255,255,255,.4);font-size:11px;padding:4px 10px;border-radius:2px;cursor:pointer;font-family:'IBM Plex Mono',monospace;}
-.tb-signout:hover{border-color:#c8590a;color:#c8590a;}
-.app{display:flex;flex:1;overflow:hidden;height:calc(100vh - 57px);}
+.app{display:flex;flex:1;overflow:hidden;height:calc(100vh - 4px);}
 #sidebar{width:260px;flex-shrink:0;background:var(--card);border-right:1px solid var(--border);overflow-y:auto;display:flex;flex-direction:column;}
 .sb-phases{padding:12px 0;}
 .sb-phase-header{padding:10px 16px 6px;font-family:'IBM Plex Mono',monospace;font-size:9px;color:var(--muted);letter-spacing:.18em;text-transform:uppercase;border-top:1px solid var(--rule);margin-top:4px;}
@@ -246,22 +235,7 @@ body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;disp
   </div>
 </div>
 
-<nav id="topbar" style="display:none">
-  <a class="nav-logo" href="/" aria-label="becomeaipm home"><img src="/assets/becomeaipm-logo-on-dark.svg" alt="becomeaipm" height="22" style="display:block;"></a>
-  <div class="nav-links">
-    <a class="nav-link active" href="/course.html">Course</a>
-    <a class="nav-link" href="/companies.html">Companies</a>
-    <a class="nav-link" href="/ai-calculator.html">AI Calculator</a>
-    <a class="nav-link" href="/analytics.html">Leaderboard</a>
-    <a class="nav-link" href="/gaps.html">Gaps</a>
-    <a class="nav-link" href="/contact.html">Contact</a>
-    <a class="nav-link" href="/pm-os.html">PM-OS</a>
-    <a class="nav-link" href="/settings.html">Settings</a>
-    <div class="tb-streak"><span class="streak-fire">&#x1F525;</span><span id="tb-streak">0 days done</span></div>
-    <div class="tb-avatar" id="tb-avatar">?</div>
-    <button class="tb-signout" onclick="doSignOut()">Sign Out</button>
-  </div>
-</nav>
+<aside id="app-nav"></aside>
 <div class="progress-bar-wrap" id="pb-wrap" style="display:none">
   <div class="progress-bar-fill" id="pb-fill" style="width:0%"></div>
 </div>
@@ -451,8 +425,7 @@ function initPendo(apiKey, user) {
           document.querySelector('.ld-spin').style.display='block';
           (async function(){
             await loadProgress();
-            renderNav(); renderSidebar(); renderDay(currentDay);
-            document.getElementById('topbar').style.display='flex';
+            renderNav(); renderDaySidebar(); renderDay(currentDay);
             document.getElementById('pb-wrap').style.display='block';
             document.getElementById('app').style.display='flex';
             updateProgress(); hideLoader();
@@ -466,8 +439,7 @@ function initPendo(apiKey, user) {
     }
     setLdText('LOADING PROGRESS...');
     await loadProgress();
-    renderNav(); renderSidebar(); renderDay(currentDay);
-    document.getElementById('topbar').style.display='flex';
+    renderNav(); renderDaySidebar(); renderDay(currentDay);
     document.getElementById('pb-wrap').style.display='block';
     document.getElementById('app').style.display='flex';
     updateProgress(); hideLoader();
@@ -525,7 +497,7 @@ function dismissAdvisorRail(){
 function goToDay(n){
   currentDay=n;
   if(typeof renderDay==='function')renderDay(n);
-  if(typeof renderSidebar==='function')renderSidebar();
+  if(typeof renderDaySidebar==='function')renderDaySidebar();
   window.scrollTo({top:0,behavior:'smooth'});
 }
 
@@ -599,16 +571,10 @@ async function saveProgress(){
   }catch(e){}
 }
 
-function renderNav(){
-  const user=clerk.user;
-  const init=(user.firstName?.[0]||user.emailAddresses?.[0]?.emailAddress?.[0]||'?').toUpperCase();
-  document.getElementById('tb-avatar').textContent=init;
-  updateStreak();
-}
-function updateStreak(){ const s=completed.size; document.getElementById('tb-streak').textContent=s+' day'+(s===1?'':'s')+' done'; }
-async function doSignOut(){ await clerk.signOut(); window.location.href='/'; }
+function renderNav(){}
+function updateStreak(){}
 
-function renderSidebar(){
+function renderDaySidebar(){
   const container=document.getElementById('sb-phases'); container.innerHTML='';
   for(const phase of PHASES){
     const header=document.createElement('div'); header.className='sb-phase-header'; header.textContent=phase.label; container.appendChild(header);
@@ -817,6 +783,8 @@ function canUsePendo(){ return localStorage.getItem('cookie_consent') === 'accep
   <button class="cookie-btn cookie-accept" onclick="acceptCookies()">Accept</button>
   <button class="cookie-btn cookie-decline" onclick="declineCookies()">Decline</button>
 </div>
+<script src="/components/nav.js"></script>
+<script>renderSidebar({ active: 'course' });</script>
 
 </body>
 </html>

--- a/public/gaps.html
+++ b/public/gaps.html
@@ -19,17 +19,12 @@
 <meta name="twitter:description" content="Live list of recent AI releases not yet in the 60-day curriculum.">
 <meta name="twitter:image" content="https://becomeaipm.com/og-image.png">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Fraunces:ital,wght@0,300;0,600;0,900;1,300;1,600&family=DM+Sans:wght@300;400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/components/nav.css">
 <style>
 :root{--bg:#f5f0e8;--bg2:#ede8df;--ink:#1a1512;--ink2:#3d3530;--muted:#8c7f74;--rule:#d4cdc4;--amber:#c8590a;--card:#faf7f2;--border:#ccc4b8;}
 *{margin:0;padding:0;box-sizing:border-box;}
 body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;min-height:100vh;}
-nav{background:var(--ink);padding:0 40px;display:flex;align-items:stretch;position:sticky;top:0;z-index:100;}
-.nav-logo{font-family:'IBM Plex Mono',monospace;font-size:12px;color:var(--amber);letter-spacing:.15em;text-decoration:none;display:flex;align-items:center;padding:14px 0;margin-right:24px;white-space:nowrap;}
-.nav-links{display:flex;align-items:stretch;gap:2px;flex:1;}
-.nav-link{font-family:'IBM Plex Mono',monospace;font-size:11px;color:rgba(255,255,255,.4);text-decoration:none;padding:0 14px;display:flex;align-items:center;border-bottom:2px solid transparent;transition:all .15s;white-space:nowrap;}
-.nav-link:hover{color:rgba(255,255,255,.8);border-bottom-color:rgba(255,255,255,.2);}
-.nav-link.active{color:var(--amber);border-bottom-color:var(--amber);}
-.hero{padding:64px 40px 16px;max-width:880px;margin:0 auto;}
+padding:64px 40px 16px;max-width:880px;margin:0 auto;}
 .label{font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.18em;color:var(--amber);text-transform:uppercase;margin-bottom:14px;}
 h1{font-family:'Fraunces',serif;font-size:clamp(34px,5vw,52px);font-weight:900;line-height:1.05;margin-bottom:14px;}
 h1 em{color:var(--amber);font-style:italic;}
@@ -59,19 +54,7 @@ footer a:hover{color:var(--amber);}
 </head>
 <body>
 
-<nav>
-  <a class="nav-logo" href="/" aria-label="becomeaipm home"><img src="/assets/becomeaipm-logo-on-dark.svg" alt="becomeaipm" height="22" style="display:block;"></a>
-  <div class="nav-links">
-    <a class="nav-link" href="/course.html">Course</a>
-    <a class="nav-link" href="/companies.html">Companies</a>
-    <a class="nav-link" href="/ai-calculator.html">AI Calculator</a>
-    <a class="nav-link" href="/analytics.html">Leaderboard</a>
-    <a class="nav-link active" href="/gaps.html">Gaps</a>
-    <a class="nav-link" href="/contact.html">Contact</a>
-    <a class="nav-link" href="/pm-os.html">PM-OS</a>
-    <a class="nav-link" href="/settings.html">Settings</a>
-  </div>
-</nav>
+<aside id="app-nav"></aside>
 
 <div class="hero">
   <div class="label">Living curriculum</div>
@@ -127,6 +110,8 @@ async function loadGaps(){
   }
 }
 loadGaps();
-</script>
+</script><script src="/components/nav.js"></script>
+<script>renderSidebar({ active: 'gaps' });</script>
+
 </body>
 </html>

--- a/public/how-to-become-ai-pm.html
+++ b/public/how-to-become-ai-pm.html
@@ -27,16 +27,11 @@
 <meta name="twitter:description" content="The complete guide — skills, path, timeline, and what AI PMs actually do.">
 <meta name="twitter:image" content="https://becomeaipm.com/og-how-to.png">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Fraunces:ital,wght@0,300;0,600;0,900;1,300;1,600&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/components/nav.css">
 <style>
 :root{--bg:#f5f0e8;--bg2:#ede8df;--ink:#1a1512;--ink2:#3d3530;--muted:#8c7f74;--rule:#d4cdc4;--amber:#c8590a;--teal:#0d6e6e;--card:#faf7f2;--border:#ccc4b8;}
 *{margin:0;padding:0;box-sizing:border-box;}
 body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;min-height:100vh;line-height:1.7;}
-nav{background:var(--ink);padding:0 40px;display:flex;align-items:stretch;position:sticky;top:0;z-index:100;}
-.nav-logo{font-family:'IBM Plex Mono',monospace;font-size:12px;color:var(--amber);letter-spacing:.15em;text-decoration:none;display:flex;align-items:center;padding:14px 0;margin-right:24px;}
-.nav-links{display:flex;align-items:stretch;gap:2px;flex:1;}
-.nav-link{font-family:'IBM Plex Mono',monospace;font-size:11px;color:rgba(255,255,255,.4);text-decoration:none;padding:0 14px;display:flex;align-items:center;border-bottom:2px solid transparent;transition:all .15s;white-space:nowrap;}
-.nav-link:hover{color:rgba(255,255,255,.8);border-bottom-color:rgba(255,255,255,.2);}
-.nav-link.active{color:var(--amber);border-bottom-color:var(--amber);}
 .hero{padding:80px 40px 40px;max-width:800px;margin:0 auto;}
 .eyebrow{font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.18em;color:var(--amber);text-transform:uppercase;margin-bottom:18px;}
 h1{font-family:'Fraunces',serif;font-size:clamp(34px,4.5vw,54px);font-weight:900;line-height:1.1;margin-bottom:18px;}
@@ -99,17 +94,7 @@ footer a:hover{color:var(--amber);}
 </head>
 <body>
 
-<nav>
-  <a class="nav-logo" href="/" aria-label="becomeaipm home"><img src="/assets/becomeaipm-logo-on-dark.svg" alt="becomeaipm" height="22" style="display:block;"></a>
-  <div class="nav-links">
-    <a class="nav-link" href="/ai-pm-course">AI PM Course</a>
-    <a class="nav-link active" href="/how-to-become-ai-pm">Guide</a>
-    <a class="nav-link" href="/ai-pm-jobs">Jobs</a>
-    <a class="nav-link" href="/ai-calculator.html">AI Calculator</a>
-    <a class="nav-link" href="/pm-os.html">PM-OS</a>
-    <a class="nav-link" href="/contact.html">Contact</a>
-  </div>
-</nav>
+<aside id="app-nav"></aside>
 
 <div class="hero">
   <div class="eyebrow">Complete Guide · Updated April 2026</div>
@@ -267,7 +252,8 @@ footer a:hover{color:var(--amber);}
 
 <footer>
   © 2026 becomeaipm · Built by <a href="https://www.linkedin.com/in/stavanmehta/" target="_blank" rel="noopener">Stavan Mehta</a> · <a href="/contact.html">Contact</a> · <a href="/ai-pm-course">Course</a> · <a href="/ai-pm-jobs">AI PM Jobs</a>
-</footer>
+</footer><script src="/components/nav.js"></script>
+<script>renderSidebar({ active: 'how-to' });</script>
 
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -28,6 +28,7 @@
   <meta name="twitter:description" content="60-day AI PM course, PM-OS, live AI PM jobs, free AI cost calculator.">
   <meta name="twitter:image" content="https://becomeaipm.com/og-image.png">
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Fraunces:ital,wght@0,300;0,600;0,900;1,300;1,600&family=DM+Sans:wght@300;400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/components/nav.css">
   <style>
     :root {
       --bg: #f5f0e8; --bg2: #ede8df; --ink: #1a1512; --ink2: #3d3530;
@@ -41,19 +42,9 @@
     .init-spin { width: 36px; height: 36px; border: 3px solid rgba(255,255,255,.1); border-top-color: var(--amber); border-radius: 50%; animation: spin .8s linear infinite; }
     .init-text { font-family: 'IBM Plex Mono', monospace; font-size: 11px; color: rgba(255,255,255,.3); letter-spacing: .12em; }
     @keyframes spin { to { transform: rotate(360deg); } }
-    nav { background: var(--ink); padding: 0 40px; display: flex; align-items: stretch; position: sticky; top: 0; z-index: 100; }
-    .nav-logo { font-family: 'IBM Plex Mono', monospace; font-size: 12px; color: var(--amber); letter-spacing: .15em; text-decoration: none; display: flex; align-items: center; padding: 14px 0; margin-right: 24px; }
-    .nav-links { display: flex; align-items: stretch; gap: 2px; flex: 1; }
-    .nav-link { font-family: 'IBM Plex Mono', monospace; font-size: 11px; color: rgba(255,255,255,.4); text-decoration: none; padding: 0 14px; display: flex; align-items: center; border-bottom: 2px solid transparent; transition: all .15s; white-space: nowrap; }
-    .nav-link:hover { color: rgba(255,255,255,.8); border-bottom-color: rgba(255,255,255,.2); }
-    .nav-link.active { color: var(--amber); border-bottom-color: var(--amber); }
-    .nav-right { display: flex; align-items: center; gap: 10px; padding: 10px 0; }
     .btn { padding: 7px 18px; border-radius: 3px; font-size: 12px; font-weight: 600; cursor: pointer; border: none; font-family: 'DM Sans', sans-serif; transition: all .15s; text-decoration: none; display: inline-flex; align-items: center; }
     .btn-ghost { background: transparent; border: 1px solid rgba(255,255,255,.2); color: rgba(255,255,255,.6); }
     .btn-ghost:hover { border-color: var(--amber); color: var(--amber); }
-    #user-menu { display: none; align-items: center; gap: 10px; }
-    .u-avatar { width: 28px; height: 28px; border-radius: 50%; background: var(--amber); color: white; font-size: 11px; font-weight: 700; display: flex; align-items: center; justify-content: center; }
-    .u-name { font-size: 12px; color: rgba(255,255,255,.6); font-family: 'IBM Plex Mono', monospace; }
     .hero { padding: 80px 40px 60px; max-width: 1100px; margin: 0 auto; }
     .hero-eyebrow { display: flex; align-items: center; gap: 12px; margin-bottom: 20px; flex-wrap: wrap; }
     .eyebrow-label { font-family: 'IBM Plex Mono', monospace; font-size: 11px; letter-spacing: .18em; color: var(--amber); text-transform: uppercase; }
@@ -126,7 +117,7 @@
     footer a { color: rgba(255,255,255,.3); text-decoration: none; }
     footer a:hover { color: var(--amber); }
     .footer-links { display: flex; gap: 20px; }
-    @media(max-width:700px) { .hero { padding: 48px 20px 40px; } .sec { padding: 48px 20px; } .demo-wrap { padding: 48px 20px; } .stack-strip { padding: 24px 20px; } .course-band { padding: 48px 20px; } footer { padding: 24px 20px; } .nav-links { display: none; } nav { padding: 0 20px; } .hero-ctas { flex-direction: column; } }
+    @media(max-width:700px) { .hero { padding: 48px 20px 40px; } .sec { padding: 48px 20px; } .demo-wrap { padding: 48px 20px; } .stack-strip { padding: 24px 20px; } .course-band { padding: 48px 20px; } footer { padding: 24px 20px; } .hero-ctas { flex-direction: column; } }
     .cookie-banner{display:none;position:fixed;bottom:0;left:0;right:0;background:var(--ink);padding:16px 40px;z-index:9999;align-items:center;justify-content:center;gap:16px;flex-wrap:wrap;}
     .cookie-banner.show{display:flex;}
     .cookie-text{font-family:'IBM Plex Mono',monospace;font-size:12px;color:rgba(255,255,255,.6);line-height:1.6;flex:1;min-width:200px;}
@@ -160,29 +151,7 @@
     <div class="init-text">INITIALIZING...</div>
   </div>
 
-  <nav>
-    <a href="/" class="nav-logo" aria-label="becomeaipm home"><img src="/assets/becomeaipm-logo-on-dark.svg" alt="becomeaipm" height="22" style="display:block;"></a>
-    <div class="nav-links">
-      <a class="nav-link" href="/course.html">Course</a>
-      <a class="nav-link" href="/companies.html">Companies</a>
-      <a class="nav-link" href="/ai-calculator.html">AI Calculator</a>
-      <a class="nav-link" href="/analytics.html">Leaderboard</a>
-      <a class="nav-link" href="/gaps.html">Gaps</a>
-      <a class="nav-link" href="/contact.html">Contact</a>
-      <a class="nav-link" href="/pm-os.html">PM-OS</a>
-      <a class="nav-link" href="/settings.html">Settings</a>
-    </div>
-    <div class="nav-right">
-      <div id="user-menu" style="display:none">
-        <div class="u-avatar" id="u-avatar">?</div>
-        <span class="u-name" id="u-name"></span>
-        <button class="btn btn-ghost" onclick="doSignOut()" style="font-size:11px;">Sign Out</button>
-      </div>
-      <div id="auth-btns">
-        <button class="btn btn-ghost" onclick="openSignIn()">Sign In</button>
-      </div>
-    </div>
-  </nav>
+<aside id="app-nav"></aside>
 
   <!-- HERO -->
   <div class="hero">
@@ -442,39 +411,15 @@ for name, s in models.items():
       setTimeout(() => l.style.display = 'none', 500);
     }
 
-    function refreshUI() {
-      const user = clerk?.user;
-      document.getElementById('auth-btns').style.display = user ? 'none' : 'flex';
-      document.getElementById('user-menu').style.display = user ? 'flex' : 'none';
-      if (user) {
-        const init = (user.firstName?.[0] || user.emailAddresses?.[0]?.emailAddress?.[0] || '?').toUpperCase();
-        document.getElementById('u-avatar').textContent = init;
-        document.getElementById('u-name').textContent = user.firstName || user.emailAddresses?.[0]?.emailAddress?.split('@')[0] || '';
-      }
-    }
+    function refreshUI() {}
 
-    function openSignIn() {
-      if (!clerk) { location.href = '/course.html'; return; }
-      clerk.openSignIn({
-        fallbackRedirectUrl: '/course.html',
-        signUpFallbackRedirectUrl: '/course.html'
-      });
-    }
-
-    async function doSignOut() { await clerk?.signOut(); refreshUI(); }
+    async function doSignOut() { await clerk?.signOut(); }
 
     function toggleTopic(el) {
       const wasOpen = el.classList.contains('open');
       document.querySelectorAll('.topic.open').forEach(t => t.classList.remove('open'));
       if (!wasOpen) el.classList.add('open');
     }
-
-    (function() {
-      var path = location.pathname;
-      document.querySelectorAll('.nav-link').forEach(function(a) {
-        if (a.getAttribute('href') === path || (path === '/' && a.getAttribute('href') === '/')) a.classList.add('active');
-      });
-    })();
 
     function acceptCookies(){ localStorage.setItem('cookie_consent','accepted'); document.getElementById('cookie-banner').classList.remove('show'); if(clerk&&clerk.user) initPendo(cfg.pendoApiKey,clerk.user); }
     function declineCookies(){ localStorage.setItem('cookie_consent','declined'); document.getElementById('cookie-banner').classList.remove('show'); }
@@ -487,6 +432,9 @@ for name, s in models.items():
     <button class="cookie-btn cookie-accept" onclick="acceptCookies()">Accept</button>
     <button class="cookie-btn cookie-decline" onclick="declineCookies()">Decline</button>
   </div>
+
+<script src="/components/nav.js"></script>
+<script>renderSidebar({});</script>
 
 </body>
 </html>

--- a/public/onboarding.html
+++ b/public/onboarding.html
@@ -11,16 +11,11 @@
 <link rel="icon" type="image/svg+xml" href="/assets/becomeaipm-mark.svg">
 <link rel="alternate icon" href="/favicon.svg">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Fraunces:ital,wght@0,300;0,600;0,900;1,300;1,600&family=DM+Sans:wght@300;400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/components/nav.css">
 <style>
 :root{--bg:#f5f0e8;--bg2:#ede8df;--ink:#1a1512;--ink2:#3d3530;--muted:#8c7f74;--rule:#d4cdc4;--amber:#c8590a;--card:#faf7f2;--border:#ccc4b8;}
 *{margin:0;padding:0;box-sizing:border-box;}
 body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;min-height:100vh;}
-nav{background:var(--ink);padding:0 40px;display:flex;align-items:stretch;position:sticky;top:0;z-index:100;}
-.nav-logo{font-family:'IBM Plex Mono',monospace;font-size:12px;color:var(--amber);letter-spacing:.15em;text-decoration:none;display:flex;align-items:center;padding:14px 0;margin-right:24px;white-space:nowrap;}
-.nav-links{display:flex;align-items:stretch;gap:2px;flex:1;}
-.nav-link{font-family:'IBM Plex Mono',monospace;font-size:11px;color:rgba(255,255,255,.4);text-decoration:none;padding:0 14px;display:flex;align-items:center;border-bottom:2px solid transparent;transition:all .15s;white-space:nowrap;}
-.nav-link:hover{color:rgba(255,255,255,.8);border-bottom-color:rgba(255,255,255,.2);}
-.nav-link.active{color:var(--amber);border-bottom-color:var(--amber);}
 .shell{max-width:720px;margin:0 auto;padding:48px 24px 80px;}
 .label{font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.18em;color:var(--amber);text-transform:uppercase;margin-bottom:14px;}
 h1{font-family:'Fraunces',serif;font-size:clamp(30px,4.2vw,42px);font-weight:900;line-height:1.1;margin-bottom:10px;}
@@ -66,19 +61,7 @@ footer a{color:rgba(255,255,255,.3);text-decoration:none;}
 </head>
 <body>
 
-<nav>
-  <a class="nav-logo" href="/" aria-label="becomeaipm home"><img src="/assets/becomeaipm-logo-on-dark.svg" alt="becomeaipm" height="22" style="display:block;"></a>
-  <div class="nav-links">
-    <a class="nav-link" href="/course.html">Course</a>
-    <a class="nav-link" href="/companies.html">Companies</a>
-    <a class="nav-link" href="/ai-calculator.html">AI Calculator</a>
-    <a class="nav-link" href="/analytics.html">Leaderboard</a>
-    <a class="nav-link" href="/gaps.html">Gaps</a>
-    <a class="nav-link" href="/contact.html">Contact</a>
-    <a class="nav-link" href="/pm-os.html">PM-OS</a>
-    <a class="nav-link" href="/settings.html">Settings</a>
-  </div>
-</nav>
+<aside id="app-nav"></aside>
 
 <div class="shell">
   <div class="label">Personalize your path</div>
@@ -276,6 +259,6 @@ function showResult(advisor){
     document.getElementById('quiz-stage').style.display='none';
   }
 })();
-</script>
+</script><script src="/components/nav.js"></script>
+<script>renderSidebar({});</script>
 </body>
-</html>

--- a/public/pm-os.html
+++ b/public/pm-os.html
@@ -27,23 +27,12 @@
 <meta name="twitter:description" content="Turn Claude Code or Copilot into a dedicated AI PM. Free & open source.">
 <meta name="twitter:image" content="https://becomeaipm.com/og-pm-os.png">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Fraunces:ital,wght@0,600;0,900&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/components/nav.css">
 <style>
 :root{--bg:#f5f0e8;--bg2:#ede8df;--ink:#1a1512;--ink2:#3d3530;--muted:#8c7f74;--border:#ccc4b8;--card:#faf7f2;--amber:#c8590a;--teal:#0d6e6e;--rule:#d4cdc4;--green:#16a34a;}
 *{margin:0;padding:0;box-sizing:border-box;}body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;min-height:100vh;}
 
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
-/* ── Nav ── */
-nav{background:var(--ink);padding:0 40px;display:flex;align-items:stretch;position:sticky;top:0;z-index:200;}
-.nav-logo{font-family:'IBM Plex Mono',monospace;font-size:12px;color:var(--amber);letter-spacing:.15em;text-decoration:none;display:flex;align-items:center;padding:14px 0;margin-right:24px;white-space:nowrap;}
-.nav-links{display:flex;align-items:stretch;gap:2px;flex:1;}
-.nav-link{font-family:'IBM Plex Mono',monospace;font-size:11px;color:rgba(255,255,255,.4);text-decoration:none;padding:0 14px;display:flex;align-items:center;border-bottom:2px solid transparent;transition:all .15s;white-space:nowrap;}
-.nav-link:hover{color:rgba(255,255,255,.8);border-bottom-color:rgba(255,255,255,.2);}
-.nav-link.active{color:var(--amber);border-bottom-color:var(--amber);}
-.nav-right{display:flex;align-items:center;gap:10px;padding:10px 0;margin-left:auto;}
-.nav-user{display:flex;align-items:center;gap:8px;}
-.nav-avatar{width:26px;height:26px;border-radius:50%;background:var(--amber);color:white;font-size:10px;font-weight:700;display:flex;align-items:center;justify-content:center;font-family:'IBM Plex Mono',monospace;}
-.nav-signout{font-family:'IBM Plex Mono',monospace;font-size:10px;color:rgba(255,255,255,.3);background:none;border:none;cursor:pointer;padding:4px 8px;}
-.nav-signout:hover{color:var(--amber);}
 
 /* ── Clerk overlay ── */
 .overlay{display:none;position:fixed;inset:0;background:rgba(0,0,0,.7);z-index:1000;align-items:center;justify-content:center;backdrop-filter:blur(4px);}
@@ -172,7 +161,6 @@ body.tool-copilot .for-copilot{display:block;}
 
 /* ── Responsive ── */
 @media(max-width:768px){
-  nav{padding:0 16px;}
   .hero,.steps,.inside-section,.tips{padding-left:20px;padding-right:20px;}
   .step-card{padding:24px 20px;}
   .tool-toggle{margin-left:20px;margin-right:20px;max-width:none;}
@@ -180,7 +168,6 @@ body.tool-copilot .for-copilot{display:block;}
   .ctx-file{flex-direction:column;align-items:flex-start;gap:4px;}
   .ctx-name{min-width:auto;}
   .stepper{padding:0 40px;}
-  .nav-links{overflow-x:auto;-webkit-overflow-scrolling:touch;}
 }
 
 /* ── Cookie banner ── */
@@ -218,25 +205,7 @@ body.tool-copilot .for-copilot{display:block;}
 </div>
 
 <!-- Navigation -->
-<nav id="main-nav">
-  <a class="nav-logo" href="/" aria-label="becomeaipm home"><img src="/assets/becomeaipm-logo-on-dark.svg" alt="becomeaipm" height="22" style="display:block;"></a>
-  <div class="nav-links">
-    <a class="nav-link" href="/course.html">Course</a>
-    <a class="nav-link" href="/companies.html">Companies</a>
-    <a class="nav-link" href="/ai-calculator.html">AI Calculator</a>
-    <a class="nav-link" href="/analytics.html">Leaderboard</a>
-    <a class="nav-link" href="/gaps.html">Gaps</a>
-    <a class="nav-link" href="/contact.html">Contact</a>
-    <a class="nav-link active" href="/pm-os.html">PM-OS</a>
-  </div>
-  <div class="nav-right">
-    <div class="nav-user" id="nav-user" style="display:none">
-      <div class="nav-avatar" id="nav-avatar">?</div>
-      <button class="nav-signout" onclick="doSignOut()">Sign Out</button>
-    </div>
-    <a class="nav-link" id="signin-pill" href="#" onclick="openSignIn();return false;" style="display:none">Sign In</a>
-  </div>
-</nav>
+<aside id="app-nav"></aside>
 
 <!-- Auth Gate (shown when not signed in) -->
 <div id="auth-gate" style="display:none">
@@ -598,18 +567,7 @@ function showAuthGate(){
   document.getElementById('auth-gate').style.display='flex';
   document.getElementById('main-content').style.display='none';
 }
-function updateAuthUI(){
-  const nu=document.getElementById('nav-user');
-  const sp=document.getElementById('signin-pill');
-  if(user){
-    document.getElementById('nav-avatar').textContent=(user.firstName?.[0]||user.emailAddresses?.[0]?.emailAddress?.[0]||'?').toUpperCase();
-    nu.style.display='flex';
-    if(sp)sp.style.display='none';
-  }else{
-    nu.style.display='none';
-    if(sp)sp.style.display='inline-flex';
-  }
-}
+function updateAuthUI(){}
 function openSignIn(){
   document.getElementById('overlay').classList.add('open');
   if(!clerkMounted&&clerk){
@@ -623,7 +581,7 @@ function closeSignIn(){
   document.getElementById('overlay').classList.remove('open');
   if(clerkMounted&&clerk){try{clerk.unmountSignIn(document.getElementById('clerk-mount'));}catch(e){}clerkMounted=false;}
 }
-async function doSignOut(){await clerk?.signOut();user=null;showAuthGate();updateAuthUI();}
+async function doSignOut(){await clerk?.signOut();user=null;showAuthGate();}
 document.getElementById('overlay').addEventListener('click',e=>{if(e.target===document.getElementById('overlay'))closeSignIn();});
 document.addEventListener('keydown',e=>{if(e.key==='Escape')closeSignIn();});
 
@@ -691,6 +649,8 @@ if(!localStorage.getItem('cookie_consent'))document.getElementById('cookie-banne
   </ul>
   <p style="margin-top:24px;font-size:13px;opacity:.6;font-family:'IBM Plex Mono',monospace;">Last reviewed April 2026 by <a href="https://www.linkedin.com/in/stavanmehta/" target="_blank" rel="noopener" style="color:#c8590a;">Stavan Mehta</a> — <a href="/contact.html" style="color:#c8590a;">send feedback</a></p>
 </section>
+<script src="/components/nav.js"></script>
+<script>renderSidebar({ active: 'pm-os' });</script>
 
 </body>
 </html>

--- a/public/settings.html
+++ b/public/settings.html
@@ -11,22 +11,11 @@
 <link rel="icon" type="image/svg+xml" href="/assets/becomeaipm-mark.svg">
 <link rel="alternate icon" href="/favicon.svg">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Fraunces:ital,wght@0,300;0,600;0,900;1,300;1,600&family=DM+Sans:wght@300;400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/components/nav.css">
 <style>
 :root{--bg:#f5f0e8;--bg2:#ede8df;--ink:#1a1512;--ink2:#3d3530;--muted:#8c7f74;--rule:#d4cdc4;--amber:#c8590a;--card:#faf7f2;--border:#ccc4b8;--green:#16a34a;--red:#dc2626;}
 *{margin:0;padding:0;box-sizing:border-box;}
 body{background:var(--bg);color:var(--ink);font-family:'DM Sans',sans-serif;min-height:100vh;}
-nav{background:var(--ink);padding:0 40px;display:flex;align-items:stretch;position:sticky;top:0;z-index:100;}
-.nav-logo{font-family:'IBM Plex Mono',monospace;font-size:12px;color:var(--amber);letter-spacing:.15em;text-decoration:none;display:flex;align-items:center;padding:14px 0;margin-right:24px;white-space:nowrap;}
-.nav-links{display:flex;align-items:stretch;gap:2px;flex:1;}
-.nav-link{font-family:'IBM Plex Mono',monospace;font-size:11px;color:rgba(255,255,255,.4);text-decoration:none;padding:0 14px;display:flex;align-items:center;border-bottom:2px solid transparent;transition:all .15s;white-space:nowrap;}
-.nav-link:hover{color:rgba(255,255,255,.8);border-bottom-color:rgba(255,255,255,.2);}
-.nav-link.active{color:var(--amber);border-bottom-color:var(--amber);}
-.nav-right{display:flex;align-items:center;gap:10px;padding:10px 0;margin-left:auto;}
-.nav-avatar{width:26px;height:26px;border-radius:50%;background:var(--amber);color:white;font-size:10px;font-weight:700;display:flex;align-items:center;justify-content:center;font-family:'IBM Plex Mono',monospace;}
-.nav-signout{font-family:'IBM Plex Mono',monospace;font-size:10px;color:rgba(255,255,255,.3);background:none;border:none;cursor:pointer;padding:4px 8px;}
-.nav-signout:hover{color:var(--amber);}
-.nav-signin{font-family:'IBM Plex Mono',monospace;font-size:11px;color:rgba(255,255,255,.4);background:none;border:1px solid rgba(255,255,255,.15);border-radius:2px;padding:4px 12px;cursor:pointer;text-decoration:none;}
-.nav-signin:hover{color:var(--amber);border-color:var(--amber);}
 .hero{padding:64px 40px 24px;max-width:760px;margin:0 auto;}
 .label{font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.18em;color:var(--amber);text-transform:uppercase;margin-bottom:16px;}
 h1{font-family:'Fraunces',serif;font-size:clamp(32px,4.5vw,48px);font-weight:900;line-height:1.1;margin-bottom:12px;}
@@ -78,25 +67,7 @@ footer a:hover{color:var(--amber);}
 </head>
 <body>
 
-<nav>
-  <a class="nav-logo" href="/" aria-label="becomeaipm home"><img src="/assets/becomeaipm-logo-on-dark.svg" alt="becomeaipm" height="22" style="display:block;"></a>
-  <div class="nav-links">
-    <a class="nav-link" href="/course.html">Course</a>
-    <a class="nav-link" href="/companies.html">Companies</a>
-    <a class="nav-link" href="/ai-calculator.html">AI Calculator</a>
-    <a class="nav-link" href="/analytics.html">Leaderboard</a>
-    <a class="nav-link" href="/gaps.html">Gaps</a>
-    <a class="nav-link" href="/contact.html">Contact</a>
-    <a class="nav-link" href="/pm-os.html">PM-OS</a>
-  </div>
-  <div class="nav-right">
-    <div id="nav-user" style="display:none">
-      <div class="nav-avatar" id="nav-avatar">?</div>
-      <button class="nav-signout" onclick="doSignOut()">Sign Out</button>
-    </div>
-    <a class="nav-signin" id="nav-signin" href="/course.html" style="display:none">Sign In</a>
-  </div>
-</nav>
+<aside id="app-nav"></aside>
 
 <div class="hero">
   <div class="label">Email Settings</div>
@@ -196,15 +167,7 @@ var clerk=null;
 var ROLE_OPTIONS=['ai pm','senior pm','staff pm','principal pm','product manager','head of product','vp product','director of product','growth pm','technical pm','associate pm','product owner'];
 var SENIORITY_OPTIONS=['junior','mid','senior','staff','principal','lead','head','director','vp'];
 
-function updateAuthUI(){
-  var user=clerk&&clerk.user;
-  document.getElementById('nav-user').style.display=user?'flex':'none';
-  document.getElementById('nav-signin').style.display=user?'none':'inline-block';
-  if(user){
-    var init=(user.firstName?.[0]||user.emailAddresses?.[0]?.emailAddress?.[0]||'?').toUpperCase();
-    document.getElementById('nav-avatar').textContent=init;
-  }
-}
+function updateAuthUI(){}
 async function doSignOut(){if(clerk){await clerk.signOut();location.reload();}}
 
 function buildChips(containerId,options,selected){
@@ -337,6 +300,6 @@ async function saveSettings(){
     }else{showSignedOut();}
   }catch(e){showSignedOut();}
 })();
-</script>
+</script><script src="/components/nav.js"></script>
+<script>renderSidebar({ active: 'settings' });</script>
 </body>
-</html>


### PR DESCRIPTION
## Why

- Every page hand-rolled its own `<nav>` block. Sprint 1 removed nav-user/avatar/signin elements from analytics.html and companies.html but left dangling `updateAuthUI` calls — broke the leaderboard for signed-in users (the bug fixed in #99 + 731499c). Drift will keep producing this class of bug.
- No room to grow into multi-course (Marketing OS / Finance OS / HR OS) or multi-calculator without crowding the top bar.
- 'Total Learners' on /analytics.html showed 2 (users with `progress_data->completed`) when actual signup count is 15.

## What

### Shared sidebar component
- New: `public/components/nav.js` + `public/components/nav.css` — vanilla JS, no build step
- One source of truth for nav HTML, auth state (avatar/sign-in/sign-out), collapse/expand (persisted in localStorage), and mobile hamburger
- Five grouped sections:
  - **Learn** — 60-Day AI PM Course
  - **PM Toolkit** — AI Calculator
  - **Discover** — Companies · AI PM Jobs · Content Gaps · How-To · PM-OS
  - **Community** — Leaderboard · Contact
  - **Account** (bottom) — Settings · avatar/Sign Out · Sign In
- Auth-aware via existing `window.Clerk` (no extra script tags needed; polls until Clerk loads)

### 13 pages wired
`index, course, companies, analytics, contact, settings, gaps, ai-pm-course, ai-pm-jobs, how-to-become-ai-pm, pm-os, ai-calculator, onboarding`. Each replaces its own `<nav>` with `<aside id="app-nav">` + the script tag. Dead `updateAuthUI` / `doSignOut` / `openSignIn` either removed or stubbed where Clerk listeners still call them.

### course.html coexistence
Existing 60-day list sidebar stays; the global sidebar adds `padding-left` to body (CSS in nav.css), so the day list naturally shifts right. Page-level `renderSidebar` was renamed to `renderDaySidebar` to avoid collision with the global `window.renderSidebar`.

### Stat fix
`api/leaderboard.js`:
- Adds a separate `COUNT(*) FROM user_access` query for `stats.totalUsers` so it reflects actual signups (15) rather than the misleading users-with-progress count (2)
- Percentile in `me` block now compares against participants instead of all signups (was using the wrong denominator)

## Files
- New: `public/components/nav.{js,css}`
- Modified: 13 HTML pages, `api/leaderboard.js`

## Test plan
- `curl /api/leaderboard` → `stats.totalUsers === 15`
- Each page renders sidebar; signed-in shows avatar + Sign Out, signed-out shows Sign In
- Active route highlighted (e.g. /analytics.html → Leaderboard amber)
- Collapse toggle persists across pages (localStorage)
- Mobile (<768px): hamburger button appears, opens overlay
- course.html: day list still works; renderDaySidebar/markDayComplete unchanged

## Out of scope
- Mobile responsive polish beyond hamburger
- Search / command palette
- Future course tracks (sidebar groups have room)