### PR TITLE
fix(audit,day-2): address Copilot review feedback from PR #107

### DIFF
--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -26,16 +26,28 @@ jobs:
       - name: Validate code examples in day-NN.js files
         run: node scripts/audit-course-content.mjs
 
-      - name: Fail if any day failed execution or has mirror mismatch
+      - name: Fail if any day failed audit
         run: |
           node -e "
             const r = require('/tmp/course-audit.json');
-            const fails = r.days.filter(d => d.exec === 'fail' || d.syntax === 'fail' || d.mirror === 'mismatch');
-            const lowOut = r.days.filter(d => d.exec === 'ok' && d.outLines !== undefined && d.outLines < 10);
-            if (fails.length || lowOut.length) {
-              console.error('FAILURES:', JSON.stringify(fails, null, 2));
-              if (lowOut.length) console.error('LOW OUTPUT:', lowOut.map(d => 'day-' + d.n + ' (' + d.outLines + ' lines)'));
+            const summary = r.summary;
+            // Strict gate: every day must be fully ok. Catches parse failures,
+            // missing files, and missing codeExample blocks (where exec/syntax
+            // would otherwise stay null and silently pass).
+            if (summary.ok !== summary.total) {
+              const issues = r.days.filter(d => d.parse !== 'ok' || d.syntax !== 'ok' || d.exec !== 'ok' || d.mirror === 'mismatch' || d.notes.length);
+              console.error('AUDIT FAILED:', JSON.stringify(summary, null, 2));
+              console.error('Days with issues:');
+              for (const d of issues) {
+                console.error('  day-' + String(d.n).padStart(2,'0') + ' parse=' + d.parse + ' syntax=' + d.syntax + ' exec=' + d.exec + ' mirror=' + d.mirror);
+                for (const note of d.notes) console.error('     ⚠  ' + note);
+              }
               process.exit(1);
             }
-            console.log('All ' + r.summary.ok + ' days passed end-to-end execution.');
+            const lowOut = r.days.filter(d => d.exec === 'ok' && d.outLines !== undefined && d.outLines < 10);
+            if (lowOut.length) {
+              console.error('LOW OUTPUT:', lowOut.map(d => 'day-' + d.n + ' (' + d.outLines + ' lines)'));
+              process.exit(1);
+            }
+            console.log('All ' + summary.ok + ' days passed end-to-end execution.');
           "

--- a/astro-app/public/days/day-02.js
+++ b/astro-app/public/days/day-02.js
@@ -83,7 +83,8 @@ def count_tokens(text: str) -> int:
     return len(bpe_like_tokens(text))
 
 def rough_word_estimate(text: str) -> int:
-    return -(-len(text.split()) // 1) * 4 // 3  # ceil(words / 0.75)
+    import math
+    return math.ceil(len(text.split()) / 0.75)
 
 # ---- 2. Context-window catalog (verify at provider docs each release) ---
 CONTEXT_WINDOWS = {

--- a/public/days/day-02.js
+++ b/public/days/day-02.js
@@ -83,7 +83,8 @@ def count_tokens(text: str) -> int:
     return len(bpe_like_tokens(text))
 
 def rough_word_estimate(text: str) -> int:
-    return -(-len(text.split()) // 1) * 4 // 3  # ceil(words / 0.75)
+    import math
+    return math.ceil(len(text.split()) / 0.75)
 
 # ---- 2. Context-window catalog (verify at provider docs each release) ---
 CONTEXT_WINDOWS = {

--- a/scripts/audit-course-content.mjs
+++ b/scripts/audit-course-content.mjs
@@ -4,10 +4,14 @@
 
 import fs from 'fs';
 import path from 'path';
+import vm from 'vm';
+import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 
-const ASTRO_DIR = 'astro-app/public/days';
-const LEGACY_DIR = 'public/days';
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const ASTRO_DIR = path.join(REPO_ROOT, 'astro-app/public/days');
+const LEGACY_DIR = path.join(REPO_ROOT, 'public/days');
+const EXTRACT_TIMEOUT_MS = 2000;
 
 const STOPWORDS = new Set([
   'the','a','an','of','to','for','in','on','and','or','with','is','are','be','as',
@@ -27,11 +31,15 @@ function tokenize(text) {
 }
 
 function extractDay(file, n) {
-  global.window = { COURSE_DAY_DATA: {} };
   const src = fs.readFileSync(file, 'utf8');
-  const fn = new Function('window', src + '\nreturn window.COURSE_DAY_DATA;');
-  const data = fn(global.window);
-  return data[n];
+  // Sandbox: no fs/process/require — only a fake `window`. vm.Script with
+  // a 2s timeout prevents a malicious or accidentally-infinite-loop day file
+  // from hanging CI.
+  const sandbox = { window: { COURSE_DAY_DATA: {} } };
+  const ctx = vm.createContext(sandbox, { name: `day-${n}` });
+  const script = new vm.Script(src, { filename: file });
+  script.runInContext(ctx, { timeout: EXTRACT_TIMEOUT_MS });
+  return sandbox.window.COURSE_DAY_DATA[n];
 }
 
 function execWithTimeout(cmd, args, code, timeoutMs = 10000) {


### PR DESCRIPTION
Four follow-ups from the Copilot review on the now-merged Sprint 9 PR (#107).

## 1. `audit-course-content.mjs` — sandbox extractor with vm.Script + timeout
Was: `new Function(window, src + '...')` running with full Node privileges (process, fs, require).
Now: `vm.Script(src).runInContext(ctx, { timeout: 2000 })` with a sandbox that only contains a fake `window`. Same parse semantics; safe in CI even on adversarial day-file content.

## 2. `audit-course-content.mjs` — path resolution from import.meta.url
The previously-unused `path` import is now actually used. `ASTRO_DIR`/`LEGACY_DIR` resolve relative to the script file (`fileURLToPath(import.meta.url)`), so `node scripts/audit-course-content.mjs` works from any cwd. Verified by running from `/tmp` — still 60/60 ok.

## 3. `.github/workflows/code-validation.yml` — strict pass gate
Was: failed only on `exec === 'fail'`, `syntax === 'fail'`, or mirror mismatch — meaning `parse === 'fail'` or missing codeExample left `exec`/`syntax` as `null` and the gate silently passed.
Now: `summary.ok !== summary.total` triggers failure, with explicit per-day diagnostics in the log.

## 4. `day-02` Python — `rough_word_estimate` ceil math
Was: `-(-len(text.split()) // 1) * 4 // 3` — that's actually `floor(words * 4 / 3)`, which underestimates (e.g., 1 word -> 1 instead of 2).
Now: `math.ceil(len(text.split()) / 0.75)` — explicit, correct, mirrored to both day-file copies.

## Validation
- `node /Users/.../scripts/audit-course-content.mjs` from `/tmp` -> 60/60 ok, 0 fail, 0 mirror-mismatch.
- Day-2 estimator output rechecked: drift values look correct (`marketing copy bpe~18 rough~16 drift -11%`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>