### PR TITLE
fix(audit): clarify vm sandbox comment; gate on missing-legacy mirror

### DIFF
--- a/scripts/audit-course-content.mjs
+++ b/scripts/audit-course-content.mjs
@@ -32,9 +32,12 @@ function tokenize(text) {
 
 function extractDay(file, n) {
   const src = fs.readFileSync(file, 'utf8');
-  // Sandbox: no fs/process/require — only a fake `window`. vm.Script with
-  // a 2s timeout prevents a malicious or accidentally-infinite-loop day file
-  // from hanging CI.
+  // Note: Node's `vm` is NOT a security sandbox against adversarial code —
+  // sandbox-escape vectors exist. We use it here for two practical benefits:
+  // (1) a 2s execution timeout that prevents an accidental infinite loop in
+  // a day file from hanging CI, and (2) scope isolation so the day file
+  // doesn't pollute the audit script's globals. Day files are vetted in PR
+  // review; this layer just guards against accidents, not malice.
   const sandbox = { window: { COURSE_DAY_DATA: {} } };
   const ctx = vm.createContext(sandbox, { name: `day-${n}` });
   const script = new vm.Script(src, { filename: file });
@@ -92,6 +95,7 @@ for (let n = 1; n <= 60; n++) {
     if (a !== l) mismatchCount++;
   } else {
     entry.mirror = 'missing-legacy';
+    mismatchCount++;
   }
 
   let day;
@@ -158,8 +162,8 @@ for (let n = 1; n <= 60; n++) {
   entry.overlapWords = intersection.slice(0, 8);
   if (intersection.length < 2) lowOverlap++;
 
-  if (entry.parse === 'ok' && entry.syntax === 'ok' && entry.exec === 'ok' && entry.mirror !== 'mismatch') okCount++;
-  else if (entry.exec === 'fail' || entry.syntax === 'fail') failCount++;
+  if (entry.parse === 'ok' && entry.syntax === 'ok' && entry.exec === 'ok' && entry.mirror === 'ok') okCount++;
+  else if (entry.exec === 'fail' || entry.syntax === 'fail' || entry.mirror !== 'ok') failCount++;
 
   report.days.push(entry);
 }


### PR DESCRIPTION
Two more Copilot review nits from PR #109.

## 1. Honest comment about `vm.Script` scope
The previous comment implied `vm` was a security sandbox. It's not — Node `vm` has known sandbox-escape vectors. The comment now states clearly that we use `vm` for (a) a 2s execution timeout that protects CI from accidental infinite loops in day files, and (b) scope isolation so day-file globals don't pollute the audit script. Day files are vetted in PR review; `vm` is not the trust layer.

## 2. `missing-legacy` mirror now fails the gate
The repo convention is that `astro-app/public/days/day-NN.js` and `public/days/day-NN.js` stay byte-identical. The audit was reporting `mirror: 'missing-legacy'` for astro-only files but counting them as `ok` in `summary.ok`, so the strict CI gate (`summary.ok !== summary.total`) would silently pass. Now `missing-legacy` is folded into `mismatchCount` and excluded from `okCount`, so an unmirrored day fails CI just like a drift would.

## Validation
`node scripts/audit-course-content.mjs` -> 60/60 ok, 0 fail, 0 mirror-mismatch.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>