### PR TITLE
fix(audit): include missing-legacy in per-day diagnostics filter

### DIFF
--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -35,7 +35,7 @@ jobs:
             // missing files, and missing codeExample blocks (where exec/syntax
             // would otherwise stay null and silently pass).
             if (summary.ok !== summary.total) {
-              const issues = r.days.filter(d => d.parse !== 'ok' || d.syntax !== 'ok' || d.exec !== 'ok' || d.mirror === 'mismatch' || d.notes.length);
+              const issues = r.days.filter(d => d.parse !== 'ok' || d.syntax !== 'ok' || d.exec !== 'ok' || d.mirror !== 'ok' || d.notes.length);
               console.error('AUDIT FAILED:', JSON.stringify(summary, null, 2));
               console.error('Days with issues:');
               for (const d of issues) {

--- a/scripts/audit-course-content.mjs
+++ b/scripts/audit-course-content.mjs
@@ -182,7 +182,7 @@ console.log('=== Course Validation Audit ===');
 console.log(JSON.stringify(report.summary, null, 2));
 console.log('\n--- Per-day issues ---');
 for (const d of report.days) {
-  if (d.notes.length || d.mirror === 'mismatch' || d.exec === 'fail' || d.syntax === 'fail' || d.overlap < 2) {
+  if (d.notes.length || d.mirror !== 'ok' || d.exec === 'fail' || d.syntax === 'fail' || d.overlap < 2) {
     console.log(`day-${String(d.n).padStart(2,'0')} lang=${d.lang} mirror=${d.mirror} syntax=${d.syntax} exec=${d.exec} logs=${d.logs} overlap=${d.overlap}${d.overlapWords?.length?' ['+d.overlapWords.join(',')+']':''}`);
     for (const note of d.notes) console.log(`   ⚠  ${note}`);
   }


### PR DESCRIPTION
Final Copilot nit from PR #110.

PR #110 made `missing-legacy` a failing state in the strict gate (`summary.ok !== summary.total`), but the audit script's per-day issue logger and the workflow's `issues` filter still only special-cased `mirror === 'mismatch'`. So an astro-only day would trip the gate but never appear in the diagnostics listing, making CI failures opaque.

Both filters now check `mirror !== 'ok'`, treating `mismatch` and `missing-legacy` uniformly.

Validation: 60/60 ok locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>